### PR TITLE
Allow URL to be provided at Resource creation for remote resources

### DIFF
--- a/src/ovation/schema.clj
+++ b/src/ovation/schema.clj
@@ -127,9 +127,11 @@
 
 (s/defschema NewRevision (-> NewEntity
                              (assoc :type (s/eq "Revision"))
-                             (assoc :attributes {:content_type s/Str
-                                                 :name         s/Str
-                                                 s/Keyword     s/Any})))
+                             (assoc :attributes {:content_type             s/Str
+                                                 :name                     s/Str
+                                                 (s/optional-key :url)     s/Str
+                                                 (s/optional-key :version) s/Str
+                                                 s/Keyword                 s/Any})))
 
 (s/defschema Revision (-> Entity
                           (assoc :type (s/eq "Revision"))

--- a/test/ovation/test/revisions.clj
+++ b/test/ovation/test/revisions.clj
@@ -128,4 +128,10 @@
             (with-fake-http [config/RESOURCES_SERVER {:status 500
                                                       :body "{}"}]
               (rev/make-resource ..auth.. {:_id        revid
-                                           :attributes {}}) => (throws ExceptionInfo))))))))
+                                           :attributes {}}) => (throws ExceptionInfo))))
+        (fact "does not create a Rails resource if :url is present already"
+          (rev/make-resource ..auth.. ..rev..) => {:revision ..rev..
+                                                   :aws      {}
+                                                   :post-url ..url..}
+          (provided
+            ..rev.. =contains=> {:url ..url..}))))))


### PR DESCRIPTION
- update Schema to show optional `:url` and `:version` in `NewRevision`
- update `make-resource` to skip Rails resource creation if `:url` already provided