### PR TITLE
Post schema object

### DIFF
--- a/src/ovation/schema.clj
+++ b/src/ovation/schema.clj
@@ -94,7 +94,7 @@
                               (s/optional-key :_collaboration_roots) [s/Str]}))
 
 
-(s/defschema EntityUpdate (dissoc BaseEntity :links :relationships))
+(s/defschema EntityUpdate (dissoc Entity :links :relationships))
 
 ;; -- Entity types --;;
 (s/defschema NewProject (-> NewEntity


### PR DESCRIPTION
Using BaseEntity didn’t include owner attribute in schema and this was
resulting in errors.