### PR TITLE
Annotation schema consistency

### DIFF
--- a/src/ovation/annotations.clj
+++ b/src/ovation/annotations.clj
@@ -22,13 +22,17 @@
 (defn- make-annotation
   [user-id entity t record]
 
-  (let [entity-id (:_id entity)]
+  (let [entity-id (:_id entity)
+        entity-collaboration-roots (links/collaboration-roots entity)
+        roots (if (or  (nil? entity-collaboration-roots) (empty? entity-collaboration-roots))
+                [entity-id]
+                entity-collaboration-roots)]
     {:user            user-id
      :entity          entity-id
      :annotation_type t
      :annotation      record
      :type            k/ANNOTATION-TYPE
-     :links           {:_collaboration_roots (links/collaboration-roots entity)}}))
+     :links           {:_collaboration_roots roots}}))
 
 (defn create-annotations
   [auth routes ids annotation-type records]
@@ -37,7 +41,6 @@
         docs (flatten (map (fn [entity]
                             (map #(make-annotation auth-user-id entity annotation-type %) records))
                         entities))]
-
     (core/create-values auth routes docs)))
 
 (defn delete-annotations

--- a/src/ovation/annotations.clj
+++ b/src/ovation/annotations.clj
@@ -13,13 +13,9 @@
   (let [db (couch/db auth)
         opts {:keys         (vec (map #(vec [% annotation-type]) ids))
               :include_docs true
-              :reduce       false}
-        annotations (couch/get-view db k/ANNOTATIONS-VIEW opts)
-        annotations-by-entity (group-by #(keyword (:entity %)) annotations)
-        grouped-annotations (map (fn [[entity annotations]]
-                                   [entity (group-by #(keyword (:user %)) annotations)]) annotations-by-entity)]
+              :reduce       false}]
 
-    (into {} grouped-annotations)))
+    (couch/get-view db k/ANNOTATIONS-VIEW opts)))
 
 
 ;; WRITE

--- a/src/ovation/links.clj
+++ b/src/ovation/links.clj
@@ -54,7 +54,7 @@
 
 (defn collaboration-roots
   [doc]
-  (get-in doc [:links :_collaboration_roots] []))
+  (get-in doc [:links :_collaboration_roots] [(:_id doc)]))
 
 (defn- add-roots
   [doc roots]

--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -20,6 +20,12 @@
         annotations (annotations/get-annotations auth [id] annotation-key)]
     (ok {(keyword annotation-key) annotations})))
 
+(defn post-annotations*
+  [request id annotation-key annotations]
+  (let [auth (:auth/auth-info request)
+        annotations-kw (keyword annotation-key)]
+    (created {annotations-kw (annotations/create-annotations auth (r/router request) [id] annotation-key annotations)})))
+
 (defmacro annotation
   "Creates an annotation type endpoint"
   [id annotation-description annotation-key record-schema annotation-schema]
@@ -38,8 +44,7 @@
          :return {(keyword ~annotation-key) [~annotation-schema]}
          :body [new-annotations# {(keyword ~annotation-key) [~record-schema]}]
          :summary ~(str "Adds a new " annotation-description " annotation to entity :id")
-         (let [auth# (:auth/auth-info request#)]
-           (created {(keyword ~annotation-key) (annotations/create-annotations auth# (r/router request#) [~id] ~annotation-key ((keyword ~annotation-key) new-annotations#))})))
+         (post-annotations* request# ~id ~annotation-key ((keyword ~annotation-key) new-annotations#)))
 
        (context* "/:annotation-id" [aid#]
          (DELETE* "/" request#

--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -14,36 +14,41 @@
             [ovation.revisions :as revisions]
             [clojure.walk :as walk]))
 
+(defn get-annotations*
+  [request id annotation-key]
+  (let [auth (:auth/auth-info request)
+        annotations (annotations/get-annotations auth [id] annotation-key)]
+    (ok {(keyword annotation-key) annotations})))
+
 (defmacro annotation
   "Creates an annotation type endpoint"
   [id annotation-description annotation-key record-schema annotation-schema]
 
-  `(context* ~(str "/" annotation-key) []
-     :tags [~annotation-key]
-     (GET* "/" request#
-       :name ~(keyword (str "get-" (lower-case annotation-key)))
-       ;:return {s/Keyword [~annotation-schema]}
-       :summary ~(str "Returns all " annotation-description " annotations associated with entity :id")
-       (let [auth# (:auth/auth-info request#)
-             annotations# (annotations/get-annotations auth# [~id] ~annotation-key)]
-         (ok {(keyword ~annotation-key) annotations#})))
+  (let [annotation-kw (keyword annotation-key)]
+    `(context* ~(str "/" annotation-key) []
+       :tags [~annotation-key]
+       (GET* "/" request#
+         :name ~(keyword (str "get-" (lower-case annotation-key)))
+         :return {~annotation-kw [~annotation-schema]}
+         :summary ~(str "Returns all " annotation-description " annotations associated with entity :id")
+         (get-annotations* request# ~id ~annotation-key))
 
-     (POST* "/" request#
-       :name ~(keyword (str "create-" (lower-case annotation-key)))
-       :return {s/Keyword [~annotation-schema]}
-       :body [new-annotations# [~record-schema]]
-       :summary ~(str "Adds a new " annotation-description " annotation to entity :id")
-       (let [auth# (:auth/auth-info request#)]
-         (created {(keyword ~annotation-key) (annotations/create-annotations auth# (r/router request#) [~id] ~annotation-key new-annotations#)})))
+       (POST* "/" request#
+         :name ~(keyword (str "create-" (lower-case annotation-key)))
+         :return {(keyword ~annotation-key) [~annotation-schema]}
+         :body [new-annotations# {(keyword ~annotation-key) [~record-schema]}]
+         :summary ~(str "Adds a new " annotation-description " annotation to entity :id")
+         (let [auth# (:auth/auth-info request#)]
+           (created {(keyword ~annotation-key) (annotations/create-annotations auth# (r/router request#) [~id] ~annotation-key ((keyword ~annotation-key) new-annotations#))})))
 
-     (context* "/:annotation-id" [aid#]
-       (DELETE* "/" request#
-         :name ~(keyword (str "delete-" (lower-case annotation-key)))
-         :return [s/Str]
-         :summary ~(str "Removes a " annotation-description " annotation from entity :id")
-         (let [auth# (:auth/auth-info request#)
-               annotation-id# (-> request# :route-params :annotation-id)]
-           (accepted (map :_id (annotations/delete-annotations auth# [annotation-id#] (r/router request#)))))))))
+       (context* "/:annotation-id" [aid#]
+         (DELETE* "/" request#
+           :name ~(keyword (str "delete-" (lower-case annotation-key)))
+           :return [s/Str]
+           :summary ~(str "Removes a " annotation-description " annotation from entity :id")
+           (let [auth# (:auth/auth-info request#)
+                 annotation-id# (-> request# :route-params :annotation-id)]
+             (accepted (map :_id (annotations/delete-annotations auth# [annotation-id#] (r/router request#))))))))))
 
 
 (defmacro get-resources

--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -50,7 +50,7 @@
          (DELETE* "/" request#
            :name ~(keyword (str "delete-" (lower-case annotation-key)))
            :return [s/Str]
-           :summary ~(str "Removes a " annotation-description " annotation from entity :id")
+           :summary ~(str "Removes a " annotation-description " annotation from entity :id. Returns a list of ids of deleted annotations.")
            (let [auth# (:auth/auth-info request#)
                  annotation-id# (-> request# :route-params :annotation-id)]
              (accepted (map :_id (annotations/delete-annotations auth# [annotation-id#] (r/router request#))))))))))

--- a/src/ovation/schema.clj
+++ b/src/ovation/schema.clj
@@ -16,7 +16,8 @@
                      :user                   s/Uuid
                      :entity                 s/Uuid
                      :type                   (s/eq "Annotation")
-                     (s/optional-key :links) {s/Keyword s/Str}})
+                     (s/optional-key :links) {(s/optional-key :_collaboration_roots) [s/Str]
+                                              s/Keyword s/Str}})
 
 (s/defschema AnnotationTypes (s/enum k/TAGS
                                      k/PROPERTIES

--- a/src/ovation/schema.clj
+++ b/src/ovation/schema.clj
@@ -15,7 +15,7 @@
                      :_rev                   s/Str
                      :user                   s/Uuid
                      :entity                 s/Uuid
-                     :type                   "Annotation"
+                     :type                   (s/eq "Annotation")
                      (s/optional-key :links) {s/Keyword s/Str}})
 
 (s/defschema AnnotationTypes (s/enum k/TAGS
@@ -24,24 +24,24 @@
                                      k/TIMELINE_EVENTS))
 
 (s/defschema TagRecord {:tag s/Str})
-(s/defschema TagAnnotation (conj AnnotationBase {:annotation_type k/TAGS
+(s/defschema TagAnnotation (conj AnnotationBase {:annotation_type (s/eq k/TAGS)
                                                  :annotation      TagRecord}))
 
 (s/defschema PropertyRecord {:key   s/Str
                              :value (describe s/Str "(may be any JSON type)")})
-(s/defschema PropertyAnnotation (conj AnnotationBase {:annotation_type k/PROPERTIES
+(s/defschema PropertyAnnotation (conj AnnotationBase {:annotation_type (s/eq k/PROPERTIES)
                                                       :annotation      PropertyRecord}))
 
 (s/defschema NoteRecord {:text      s/Str
                          :timestamp s/Str})
-(s/defschema NoteAnnotation (conj AnnotationBase {:annotation_type k/NOTES
+(s/defschema NoteAnnotation (conj AnnotationBase {:annotation_type (s/eq k/NOTES)
                                                   :annotation      NoteRecord}))
 
 (s/defschema TimelineEventRecord {:name                 s/Str
                                   :notes                s/Str
                                   :start                s/Str
                                   (s/optional-key :end) s/Str})
-(s/defschema TimelineEventAnnotation (conj AnnotationBase {:annotation_type k/TIMELINE_EVENTS
+(s/defschema TimelineEventAnnotation (conj AnnotationBase {:annotation_type (s/eq k/TIMELINE_EVENTS)
                                                            :annotation      TimelineEventRecord}))
 
 

--- a/test/ovation/test/annotations.clj
+++ b/test/ovation/test/annotations.clj
@@ -34,10 +34,11 @@
                 :_rev            ..rev..
                 :entity          id2
                 :user            user2}]
-        (a/get-annotations ..auth.. [id1 id2] ..type..) => {(keyword id1) {(keyword user1) [a1]
-                                                                           (keyword user2) [a2]}
-                                                            (keyword id2) {(keyword user1) [a3]
-                                                                           (keyword user2) [a4]}}
+        (a/get-annotations ..auth.. [id1 id2] ..type..) => [a1 a2 a3 a4]
+        ;{(keyword id1) {(keyword user1) [a1]
+        ;                                                                   (keyword user2) [a2]}
+        ;                                                    (keyword id2) {(keyword user1) [a3]
+        ;                                                                   (keyword user2) [a4]}}
         (provided
           (couch/get-view ..db.. "annotation_docs" {:keys         [[id1 ..type..]
                                                                    [id2 ..type..]]

--- a/test/ovation/test/handler.clj
+++ b/test/ovation/test/handler.clj
@@ -138,7 +138,7 @@
 
       (facts "POST /entities/:id/annotations/:type"
         (let [id (str (util/make-uuid))
-              post [{:tag "--tag--"}]
+              post {:tags [{:tag "--tag--"}]}
               tags [{:_id             (str (util/make-uuid))
                      :_rev            "1"
                      :entity          id
@@ -146,7 +146,7 @@
                      :type            "Annotation"
                      :annotation_type "tags"
                      :annotation      {:tag "--tag--"}}]]
-          (against-background [(annotations/create-annotations auth-info anything [id] "tags" post) => tags]
+          (against-background [(annotations/create-annotations auth-info anything [id] "tags" (:tags post)) => tags]
             (fact "creates annotations"
               (let [path (str "/api/v1/entities/" id "/annotations/tags")
                     {:keys [status body]} (post* app path apikey post)]


### PR DESCRIPTION
Updates to annotation resource schema to be consistent with the GET/POST schema for entities.

GET `/entities/:id/annotations` now returns

```
{:tags [{...tag record...}]}
```

POST `/entities/:id/annotations` with
```
{:tags [{...new tag...}]}
```
and returns
```
{:tags [{...tag record...}]}
```