### PR TITLE
Protect collaboration root updates

### DIFF
--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -143,7 +143,7 @@
             entities (core/create-entities auth body routes :parent id)
             child-links (make-child-links* auth id type-name entities routes)
             links (core/create-values auth routes (:links child-links))
-            updates (core/update-entities auth (:updates child-links) routes :authorize false)]
+            updates (core/update-entities auth (:updates child-links) routes :authorize false :update-collaboration-roots true)]
 
         (created {:entities entities
                   :links    links
@@ -249,7 +249,7 @@
         (let [groups (group-by :inverse_rel new-links)
               link-groups (map (fn [[irel nlinks]] (links/add-links auth [source] rel (map :target_id nlinks) routes :inverse-rel irel)) (seq groups))]
           (let [links (core/create-values auth routes (flatten (map :links link-groups)))
-                updates (core/update-entities auth (flatten (map :updates link-groups)) routes :authorize false)]
+                updates (core/update-entities auth (flatten (map :updates link-groups)) routes :authorize false  :update-collaboration-roots true)]
             (created {:updates updates
                       :links   links})))
         (not-found {:errors {:detail (str ~id " not found")}})))

--- a/test/ovation/test/handler.clj
+++ b/test/ovation/test/handler.clj
@@ -284,7 +284,7 @@
                                     (core/get-entities auth-info# [(:_id parent#)] ..rt..) => [parent#]
                                     (links/add-links auth-info# [parent#] rel# [(:_id entity#)] ..rt.. :inverse-rel inverse_rel#) => {:links links#}
                                     (core/create-values auth-info# ..rt.. links#) => links#
-                                    (core/update-entities auth-info# anything ..rt.. :authorize false) => ..updates..
+                                    (core/update-entities auth-info# anything ..rt.. :authorize false :update-collaboration-roots true) => ..updates..
                                     (r/router anything) => ..rt..]
                  (fact "POST /:id returns status 201"
                    (let [post# (request#)]

--- a/test/ovation/test/route_helpers.clj
+++ b/test/ovation/test/route_helpers.clj
@@ -42,4 +42,4 @@
         (core/get-entities ..auth.. [..id2..] ..rt..) => (seq [source-entity])
         (core/create-entities ..auth.. [{:type "Source" :attributes {}}] ..rt.. :parent ..fileid..) => [source-entity]
         (core/create-values ..auth.. ..rt.. anything) => ..links..
-        (core/update-entities ..auth.. anything ..rt.. :authorize false) => ..updates..))))
+        (core/update-entities ..auth.. anything ..rt.. :authorize false :update-collaboration-roots true) => ..updates..))))


### PR DESCRIPTION
Protects collaboration roots from entity updates. Only allow when
calling from relationship creation updates.