### PR TITLE
Fixes Project creation failure on teams API auth

### DIFF
--- a/src/ovation/core.clj
+++ b/src/ovation/core.clj
@@ -78,9 +78,6 @@
                                                :collaboration_roots (parent-collaboration-roots auth parent routes)))
                      auth
                      routes)]
-      ;; create teams for new Project entities
-      (doall (map #(teams/create-team {:identity auth} (:_id %)) (filter #(= (:type %) k/PROJECT-TYPE) entities)))
-
       entities)))
 
 (defn create-values

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -14,7 +14,7 @@
             [clojure.tools.logging :as logging]
             [ovation.config :as config]
             [ovation.core :as core]
-            [ovation.middleware.auth :refer [wrap-jwt wrap-authenticated-teams]]
+            [ovation.middleware.auth :refer [wrap-authenticated-teams]]
             [ovation.links :as links]
             [ovation.routes :as r]
             [ovation.auth :as auth]
@@ -48,10 +48,6 @@
                                     :on-error auth/throw-unauthorized})
 
                 (wrap-authenticated-teams)
-
-                ;(wrap-jwt
-                ;  :wraper (wrap-authentication (jws-backend {:secret config/JWT_SECRET}))
-                ;  :required-auth-url-prefix #{"/api"})
 
 
                 (wrap-with-logger {;;TODO can we make the middleware conditional rather than testing for each logging call?

--- a/src/ovation/middleware/auth.clj
+++ b/src/ovation/middleware/auth.clj
@@ -14,13 +14,3 @@
         (assoc-in [:identity ::auth/authenticated-teams] (teams/teams (auth/token request)))
         (handler))
       (handler request))))
-
-
-(defn wrap-jwt
-  "Wrap the response with JWT token authentication"
-  [handler & {:keys [wraper required-auth-url-prefix]}]
-  (fn [request]
-    (if (and required-auth-url-prefix
-          (not (empty? (filter #(.startsWith (lower-case (:uri request)) (lower-case %)) required-auth-url-prefix))))
-      (wraper request)
-      (handler request))))

--- a/src/ovation/teams.clj
+++ b/src/ovation/teams.clj
@@ -12,9 +12,9 @@
             [slingshot.support :refer [get-throwable]]))
 
 
-(defn api-key
+(defn auth-token
   [request]
-  (::auth/api-key request))
+  (auth/token request))
 
 (defn make-url
   [& comps]
@@ -37,7 +37,7 @@
   [request team-uuid]
 
   (logging/info (str "Creating Team for " team-uuid))
-  (let [opts (request-opts (api-key request))
+  (let [opts (request-opts (auth-token request))
         url (make-url "teams")
         body (util/to-json {:team {:uuid (str team-uuid)}})
         response @(httpkit.client/post url (assoc opts :body body))]
@@ -48,7 +48,7 @@
 (defn get-team*
   [request team-id]
   (let [rt (routes/router request)
-        opts (request-opts (api-key request))
+        opts (request-opts (auth-token request))
         url (make-url "teams" team-id)
         response @(httpkit.client/get url opts)]
 
@@ -93,7 +93,7 @@
 (defn put-membership*
   [request team-uuid membership membership-id]                              ;; membership is a TeamMembership
   (let [rt (routes/router request)
-        opts (request-opts (api-key request))
+        opts (request-opts (auth-token request))
         url (make-url "memberships" membership-id)
         role-id (get-in membership [:role :id])
         body {:membership {:role_id role-id}}]
@@ -111,7 +111,7 @@
 (defn post-membership*
   [request team-uuid membership]                            ;; membership is a NewTeamMembership
   (let [rt      (routes/router request)
-        opts    (request-opts (api-key request))
+        opts    (request-opts (auth-token request))
         url     (make-url "memberships")
         team    (get-team* request team-uuid)
         team-id (get-in team [:team :id])
@@ -133,7 +133,7 @@
 
 (defn delete-membership*
   [request membership-id]
-  (let [opts (request-opts (api-key request))
+  (let [opts (request-opts (auth-token request))
         url (make-url "memberships" membership-id)]
 
     (let [response @(httpkit.client/delete url opts)]
@@ -142,7 +142,7 @@
 
 (defn get-roles*
   [request]
-  (let [opts (request-opts (api-key request))
+  (let [opts (request-opts (auth-token request))
         url (make-url "roles")]
 
     (let [response @(httpkit.client/get url opts)]

--- a/test/ovation/test/core.clj
+++ b/test/ovation/test/core.clj
@@ -133,7 +133,6 @@
                                              :attributes attributes}] ..routes.. :parent nil) => [{:type "Project"
                                                                                                    :_id  ..id..}]
             (provided
-              (teams/create-team {:identity ..auth..} ..id..) => ..team..
               (tw/to-couch ...owner-id... [{:type       "Project"
                                             :attributes attributes}]
                 :collaboration_roots []) => [...doc...]

--- a/test/ovation/test/handler.clj
+++ b/test/ovation/test/handler.clj
@@ -268,6 +268,7 @@
         type-path (typepath type-name)]
     `(let [apikey# TOKEN]
        (against-background [(teams/teams anything) => TEAMS
+                            (teams/create-team anything anything) => {:team ..team..}
                             (auth/identity anything) => ..auth..]
          (facts ~(util/join-path ["" type-path])
            (facts "resource"
@@ -321,6 +322,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/teams anything) => TEAMS
+                            (teams/create-team anything anything) => {:team ..team..}
                             (auth/identity anything) => ..auth..]
          (facts ~(util/join-path ["" type-path])
            (facts "create"


### PR DESCRIPTION
Moves team creation from `core/create-entities` to `route-helpers/post-resources*` so that `teams/create-teams` can get the request (with authentication token)