### PR TITLE
Team and permission perf

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -70,6 +70,10 @@
                                               [ring-serve "0.1.2"]]
                                :plugins      [[lein-midje "3.2"]
                                               [lein-ring "0.9.7"]]}
+             :jmx             {:jvm-opts ["-Dcom.sun.management.jmxremote"
+                                          "-Dcom.sun.management.jmxremote.ssl=false"
+                                          "-Dcom.sun.management.jmxremote.authenticate=false"
+                                          "-Dcom.sun.management.jmxremote.port=43210"]}
              :ci              {:aws {:access-key ~(System/getenv "AWS_ACCESS_KEY")
                                      :secret-key ~(System/getenv "AWS_SECRET_KEY")}}}
 

--- a/src/ovation/auth.clj
+++ b/src/ovation/auth.clj
@@ -52,6 +52,7 @@
               :query-params {:uuids (json/write-str (map str collaboration-roots))}
               :accept       :json}]
 
+    (println "get-permissions")
     (let [response @(http/get url opts)]
       (when (not (hp/ok? response))
         (logging/error "Unable to retrieve object permissions")
@@ -70,7 +71,7 @@
   "Get all teams to which the authenticated user belongs or nil on failure or non-JSON response"
   [auth]
   (if-let [ateams (::authenticated-teams auth)]
-    (deref ateams 5000 [])))
+    (deref ateams 500 [])))
 
 (defn effective-collaboration-roots
   [doc]

--- a/src/ovation/auth.clj
+++ b/src/ovation/auth.clj
@@ -64,7 +64,7 @@
 
 (defn get-permissions
   [auth collaboration-roots]
-  (let [permissions @(::authenticated-permissions auth)
+  (let [permissions (deref (::authenticated-permissions auth) 500 [])
         root-set (set collaboration-roots)]
     (filter #(contains? root-set (:uuid %)) permissions)))  ;;TODO we should collect once and then select-keys
 

--- a/src/ovation/middleware/auth.clj
+++ b/src/ovation/middleware/auth.clj
@@ -12,5 +12,6 @@
     (if (auth/authenticated? request)
       (-> request
         (assoc-in [:identity ::auth/authenticated-teams] (teams/get-teams (auth/token request)))
+        (assoc-in [:identity ::auth/authenticated-permissions] (auth/permissions (auth/token request)))
         (handler))
       (handler request))))

--- a/src/ovation/teams.clj
+++ b/src/ovation/teams.clj
@@ -31,13 +31,13 @@
   "Gets all teams for authenticated user as a future: [id1 id2]"
   [api-token]
   (let [opts (request-opts api-token)
-        url  (make-url "teams")]
+        url  (make-url "team_uuids")]
     (future (let [resp @(httpkit.client/get url opts)]
               (if (hp/ok? resp)
-                (map :uuid (-> resp
-                             :body
-                             util/from-json
-                             :teams)))))))
+                (-> resp
+                  :body
+                  util/from-json
+                  :team_uuids))))))
 
 (defn create-team
   [request team-uuid]

--- a/test/ovation/test/handler.clj
+++ b/test/ovation/test/handler.clj
@@ -30,6 +30,9 @@
 (def TEAMS (promise))
 (deliver TEAMS [])
 
+(def PERMISSIONS (promise))
+(deliver PERMISSIONS {})
+
 
 (defn sling-throwable
   [exception-map]
@@ -129,6 +132,7 @@
 (facts "About annotations"
   (let [apikey TOKEN]
     (against-background [(teams/get-teams anything) => TEAMS
+                         (auth/permissions anything) => PERMISSIONS
                          (auth/identity anything) => ..auth..]
       (facts "GET /entities/:id/annotations/:type"
         (let [id   (str (util/make-uuid))
@@ -174,6 +178,7 @@
                             :annotation_type "tags"
                             :annotation      {:tag "--tag--"}}]]
         (against-background [(teams/get-teams anything) => TEAMS
+                             (auth/permissions anything) => PERMISSIONS
                              (auth/identity anything) => ..auth..
                              (annotations/delete-annotations ..auth.. [annotation-id] anything) => tags]
           (fact "deletes annotations"
@@ -185,6 +190,7 @@
 (facts "About /entities"
   (let [apikey TOKEN]
     (against-background [(teams/get-teams anything) => TEAMS
+                         (auth/permissions anything) => PERMISSIONS
                          (auth/identity anything) => ..auth..]
 
       (facts "read"
@@ -211,6 +217,7 @@
         type-path (typepath type-name)]
     `(let [apikey# TOKEN]
        (against-background [(teams/get-teams anything) => TEAMS
+                            (auth/permissions anything) => PERMISSIONS
                             (auth/identity anything) => ..auth..]
          (facts ~(util/join-path ["" type-path])
            (facts "resources"
@@ -235,6 +242,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
+                            (auth/permissions anything) => PERMISSIONS
                             (auth/identity anything) => ..auth..]
          (facts ~(util/join-path ["" type-path])
            (facts "resource"
@@ -268,6 +276,7 @@
         type-path (typepath type-name)]
     `(let [apikey# TOKEN]
        (against-background [(teams/get-teams anything) => TEAMS
+                            (auth/permissions anything) => PERMISSIONS
                             (teams/create-team anything anything) => {:team ..team..}
                             (auth/identity anything) => ..auth..]
          (facts ~(util/join-path ["" type-path])
@@ -322,6 +331,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
+                            (auth/permissions anything) => PERMISSIONS
                             (teams/create-team anything anything) => {:team ..team..}
                             (auth/identity anything) => ..auth..]
          (facts ~(util/join-path ["" type-path])
@@ -366,6 +376,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
+                            (auth/permissions anything) => PERMISSIONS
                             (auth/identity anything) => ..auth..]
          (facts ~(util/join-path ["" type-path])
            (facts "update"
@@ -422,6 +433,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
+                            (auth/permissions anything) => PERMISSIONS
                             (auth/identity anything) => ..auth..]
 
          (facts ~(util/join-path ["" type-path])
@@ -488,6 +500,7 @@
   (facts "related Sources"
     (let [apikey TOKEN]
       (against-background [(teams/get-teams anything) => TEAMS
+                           (auth/permissions anything) => PERMISSIONS
                            (auth/identity anything) => ..auth..]
         (future-fact "associates created Source")))))
 
@@ -524,6 +537,7 @@
           (body-json get) => {:revisions revs}
           (provided
             (teams/get-teams anything) => TEAMS
+            (auth/permissions anything) => PERMISSIONS
             (auth/identity anything) => ..auth..
             (core/get-entities ..auth.. [id] ..rt..) => [doc]
             (r/router anything) => ..rt..
@@ -571,6 +585,7 @@
         (body-json get) => {:team team}
         (provided
           (teams/get-teams anything) => TEAMS
+          (auth/permissions anything) => PERMISSIONS
           (teams/get-team* anything id) => {:team team})))))
 
 (facts "About activity user stories"
@@ -590,6 +605,7 @@
       (body-json get) => {:provenance expected}
       (provided
         (teams/get-teams anything) => TEAMS
+        (auth/permissions anything) => PERMISSIONS
         (auth/identity anything) => ..auth..
         (prov/local ..auth.. ..rt.. [id]) => expected
         (r/router anything) => ..rt..))))

--- a/test/ovation/test/teams.clj
+++ b/test/ovation/test/teams.clj
@@ -11,13 +11,13 @@
 
 (facts "About Teams API"
   (facts "teams"
-    (let [teams-url (util/join-path [config/TEAMS_SERVER "teams"])
-          teams     [{:uuid "uuid1"} {:uuid "uuid2"}]]
+    (let [teams-url (util/join-path [config/TEAMS_SERVER "team_uuids"])
+          teams     ["uuid1" "uuid2"]]
       (with-fake-http [{:url teams-url :method :get} {:status 200
-                                                      :body   (util/to-json {:teams teams})}]
+                                                      :body   (util/to-json {:team_uuids teams})}]
 
         (fact "calls /teams"
-          @(teams/get-teams ..apikey..) => ["uuid1" "uuid2"]))))
+          @(teams/get-teams ..apikey..) => teams))))
 
   (facts "get-team*"
     (against-background [(auth/authenticated-user-id ..auth..) => ..user-id..


### PR DESCRIPTION
- [x] Uses `team_uuids` for faster team access
- [x] Makes a single call for all permissions to `/api/v2/permissions` and stores future in auth (like teams)