### PR TITLE
Single annotation update

### DIFF
--- a/deploy_catalyze.sh
+++ b/deploy_catalyze.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash 
+#!/usr/bin/env bash
 
 # Associate catalyze environment
 git remote add catalyze ssh://git@git.pod02.catalyzeapps.com:2222/pod02234-code-927176715.git

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -34,6 +34,9 @@
 (def rules [{:pattern #"^/api.*"
              :handler authenticated?}])
 
+(def DESCRIPTION "<p>Ovation REST API.</p>
+                 <figure><img src=\"static/data_model.png\" alt=\"Ovation data model\"></figure>")
+
 ;;; --- Routes --- ;;;
 (defapi app
   {:swagger {:ui "/"
@@ -41,7 +44,7 @@
              :data {:info {
                            :version        "2.0.0"
                            :title          "Ovation"
-                           :description    "Ovation REST API. Read an introduction <a href=\"https://github.com/physion/ovation-webapi\">here</a>."
+                           :description    DESCRIPTION
                            :contact        {:name "Ovation"
                                             :url  "https://www.ovation.io"}
                            :termsOfService "https://services.ovation.io/terms_of_service"}
@@ -330,3 +333,4 @@
             :return {:roles [TeamRole]}
             :summary "Gets all team Roles for the current Organization"
             (ok (teams/get-roles* request))))))))
+

--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -35,11 +35,9 @@
 
 (defn put-annotation*
   [request annotation-key annotation-id annotation]
-  (let [auth (auth/identity request)]
-    (when-not (= (str (:_id annotation)) (str annotation-id))
-      (bad-request! {:errors {:_id "Annotation _id does not match"}}))
 
-    (ok {(keyword annotation-key) (first (annotations/update-annotations auth (r/router request) [annotation]))})))
+  (let [auth (auth/identity request)]
+    (ok {(keyword annotation-key) (annotations/update-annotation auth (r/router request) annotation-id annotation)})))
 
 
 (defn annotation
@@ -75,7 +73,7 @@
           (PUT "/" request
             :name (keyword (str "update-" (lower-case annotation-key)))
             :return {:note annotation-schema}
-            :body [update {:note annotation-schema}]
+            :body [update {:note record-schema}]
             :summary (str "Updates a " annotation-description " annotation to entity :id.")
             (put-annotation* request "note" annotation-id (:note update))))))))
 

--- a/test/ovation/test/annotations.clj
+++ b/test/ovation/test/annotations.clj
@@ -84,7 +84,7 @@
                                                                      :links {:_collaboration_roots [..root2..]}}]
           (core/create-values ..auth.. ..rt.. expected) => ..result..))))
 
-  (facts "About update-annotations"
+  (facts "About update-annotation"
     (facts "authorized user"
       (against-background [(auth/authenticated-user-id ..auth..) => ..user..]
 
@@ -94,16 +94,8 @@
                          :user            ..user..
                          :annotation_type c/NOTES
                          :type            c/ANNOTATION-TYPE
-                         :annotation      {:note ..new..}}
-
-                note    {:_id             ..uuid..
-                         :entity          ..entity..
-                         :user            ..user..
-                         :annotation_type c/NOTES
-                         :type            c/ANNOTATION-TYPE
-                         :annotation      {:note ..new..}
-                         :foo             :bar}]
-            (a/update-annotations ..auth.. ..rt.. [note]) => ..result..
+                         :annotation      {:note ..old..}}]
+            (a/update-annotation ..auth.. ..rt.. ..uuid.. {:note ..new..}) => ..result..
             (provided
               (util/iso-short-now) => ..time..
               (core/get-values ..auth.. [..uuid..] :routes ..rt..) => [current]
@@ -113,7 +105,7 @@
                                                     :annotation_type c/NOTES
                                                     :type            c/ANNOTATION-TYPE
                                                     :annotation      {:note ..new..}
-                                                    :edited_at       ..time..}]) => ..result..)))
+                                                    :edited_at       ..time..}]) => [..result..])))
 
 
         (fact "raises 422 for non-note annotation"
@@ -123,7 +115,9 @@
                      :annotation_type c/TAGS
                      :type            c/ANNOTATION-TYPE
                      :annotation      {:tag ..tag..}}]
-            (a/update-annotations ..auth.. ..rt.. [tag]) => (throws ExceptionInfo)))))
+            (a/update-annotation ..auth.. ..rt.. ..uuid.. {:tag ..new..}) => (throws ExceptionInfo)
+            (provided
+              (core/get-values ..auth.. [..uuid..] :routes ..rt..) => tag)))))
 
     (facts "unauthorized user"
       (against-background [(auth/authenticated-user-id ..auth..) => ..other..]
@@ -134,7 +128,9 @@
                      :annotation_type c/TAGS
                      :type            c/ANNOTATION-TYPE
                      :annotation      {:tag ..tag..}}]
-            (a/update-annotations ..auth.. ..rt.. [tag]) => (throws ExceptionInfo))))))
+            (a/update-annotation ..auth.. ..rt.. ..uuid.. {:tag ..new..}) => (throws ExceptionInfo)
+            (provided
+              (core/get-values ..auth.. [..uuid..] :routes ..rt..) => [tag]))))))
 
   (facts "About `delete-annotations`"
     (fact "calls `delete-values"

--- a/test/ovation/test/handler.clj
+++ b/test/ovation/test/handler.clj
@@ -192,10 +192,10 @@
                          :annotation_type c/NOTES
                          :annotation      {:text      "--note--"
                                            :timestamp (util/iso-short-now)}}]
-          (against-background [(annotations/update-annotations ..auth.. anything anything) => [update]]
+          (against-background [(annotations/update-annotation ..auth.. anything (str note-id) (:annotation update)) => update]
             (fact "updates annotation"
               (let [path (str "/api/v1/entities/" entity-id "/annotations/notes/" note-id)
-                    {:keys [status body]} (put* app path apikey {:note update})]
+                    {:keys [status body]} (put* app path apikey {:note (:annotation update)})]
                 status => 200
                 body => {:note update}))))))
 


### PR DESCRIPTION
Update a single annotation, passing only the `:annotation` record. This
is how the front-end wants it.

Closes #178