### PR TITLE
[Delivers #120015903] Return Access-Control headers when Origin present

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [metosin/ring-swagger-ui "2.1.4-0"]
                  [ring-cors "0.1.7"]
                  [ring-logger "0.7.6"]
-                 [buddy/buddy-auth "0.12.0"]
+                 [buddy/buddy-auth "0.13.0"]
                  [ring/ring-jetty-adapter "1.4.0"]
 
 

--- a/src/ovation/auth.clj
+++ b/src/ovation/auth.clj
@@ -3,10 +3,9 @@
   (:require [org.httpkit.client :as http]
             [ovation.util :as util :refer [<??]]
             [ring.util.http-predicates :as hp]
-            [ring.util.http-response :refer [throw! unauthorized! forbidden!]]
+            [ring.util.http-response :refer [throw! unauthorized! forbidden! unauthorized forbidden]]
             [slingshot.slingshot :refer [throw+]]
             [clojure.tools.logging :as logging]
-            [clojure.data.json :as json]
             [buddy.auth]
             [ovation.config :as config]))
 
@@ -35,12 +34,12 @@
       (assoc id ::token (token request))
       id)))
 
-(defn throw-unauthorized
+(defn unauthorized-response
   "A default response constructor for an unathorized request."
   [request value]
   (if (authenticated? request)
-    (forbidden! "Permission denied")
-    (unauthorized! "Unauthorized")))
+    (forbidden "Permission denied")
+    (unauthorized "Unauthorized")))
 
 
 (defn authenticated-user-id

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -89,13 +89,13 @@
                [wrap-authentication (jws-backend {:secret     config/JWT_SECRET
                                                   :token-name "Bearer"})]
                [wrap-access-rules {:rules    rules
-                                   :on-error auth/throw-unauthorized}]
+                                   :on-error auth/unauthorized-response}]
 
                wrap-authenticated-teams
 
                [logger.timbre/wrap-with-logger {:printer :identity-printer}]
 
-               [wrap-raygun-handler (System/getenv "RAYGUN_API_KEY")]
+               [wrap-raygun-handler (config/config "RAYGUN_API_KEY")]
 
                wrap-newrelic-transaction]
 

--- a/test/ovation/test/handler.clj
+++ b/test/ovation/test/handler.clj
@@ -25,7 +25,6 @@
   (:import (java.util UUID)))
 
 (def id {:uuid (UUID/randomUUID)})
-(jws/sign id (config/config "JWT_SECRET"))
 
 (def TOKEN (jws/sign id (config/config "JWT_SECRET")))
 


### PR DESCRIPTION
Even for 401/403 responses, return an Access-Control header when Origin
present.

- upgrade to buddy-auth 0.13.0
- ring-cors handler first
- don't throw exception for unauthorized—just return the body

[#120015903]