### PR TITLE
Allow :delete on Relation

### DIFF
--- a/src/ovation/auth.clj
+++ b/src/ovation/auth.clj
@@ -135,7 +135,10 @@
   (let [auth-user-id (authenticated-user-id auth)]
     (case (:type doc)
       "Annotation" (= auth-user-id (:user doc))
-      "Relation" (= auth-user-id (:user_id doc))
+      "Relation" (or (= auth-user-id (:user_id doc))
+                   (let [roots (get-in doc [:links :_collaboration_roots])
+                         permissions (get-permissions auth roots)]
+                     (every? true? (collect-permissions permissions :write))))
 
       ;; default
       (let [permissions (get-permissions auth (effective-collaboration-roots doc))]

--- a/src/ovation/auth.clj
+++ b/src/ovation/auth.clj
@@ -142,7 +142,7 @@
 
       ;; default
       (let [permissions (get-permissions auth (effective-collaboration-roots doc))]
-        (or (every? true? (collect-permissions permissions :admin))
+        (or (every? true? (collect-permissions permissions :write))
           (= auth-user-id (:owner doc)))))))
 
 (defn- can-read?

--- a/src/ovation/auth.clj
+++ b/src/ovation/auth.clj
@@ -142,7 +142,7 @@
 
       ;; default
       (let [permissions (get-permissions auth (effective-collaboration-roots doc))]
-        (or (every? true? (collect-permissions permissions :write))
+        (or (every? true? (collect-permissions permissions :admin))
           (= auth-user-id (:owner doc)))))))
 
 (defn- can-read?

--- a/src/ovation/transform/read.clj
+++ b/src/ovation/transform/read.clj
@@ -35,8 +35,8 @@
         relationships (EntityRelationships entity-type)
         links (into {} (map (fn [[rel _]]
                               [rel {:self (r/relationship-route rt dto rel)
-                                            :related (r/targets-route rt dto rel)}]
-                              ) relationships))]
+                                          :related (r/targets-route rt dto rel)}])
+                            relationships))]
 
     (assoc-in dto [:relationships] (merge links (get dto :relationships {})))))
 
@@ -110,9 +110,9 @@
       "unauthorized" (unauthorized!)
       (condp = (util/entity-type-name doc)
         c/RELATION-TYPE-NAME (-> doc
-                               (add-self-link router)
+                               (add-self-link router))
                                ;(add-value-permissions auth)
-                               )
+
         ;; default
         (add-value-permissions doc auth)))))
 

--- a/test/ovation/test/auth.clj
+++ b/test/ovation/test/auth.clj
@@ -220,7 +220,7 @@
             (auth/can? ..auth.. ::auth/delete doc) => true
             (provided
               (auth/get-permissions ..auth.. ..roots..) => ..permissions..
-              (auth/collect-permissions ..permissions.. :write) => [true true]))))
+              (auth/collect-permissions ..permissions.. :admin) => [true true]))))
       (fact "Annoations require :user match authenticated user"
         (auth/can? ..auth.. ::auth/delete {:type "Annotation"
                                            :user ..user..}) => true

--- a/test/ovation/test/auth.clj
+++ b/test/ovation/test/auth.clj
@@ -220,7 +220,7 @@
             (auth/can? ..auth.. ::auth/delete doc) => true
             (provided
               (auth/get-permissions ..auth.. ..roots..) => ..permissions..
-              (auth/collect-permissions ..permissions.. :admin) => [true true]))))
+              (auth/collect-permissions ..permissions.. :write) => [true true]))))
       (fact "Annoations require :user match authenticated user"
         (auth/can? ..auth.. ::auth/delete {:type "Annotation"
                                            :user ..user..}) => true

--- a/test/ovation/test/links.clj
+++ b/test/ovation/test/links.clj
@@ -16,15 +16,15 @@
           doc2 {:attributes {:label ..label2..}}
           doc3 {:attributes {}}]
       (against-background [(couch/get-view ..auth.. ..db.. k/LINKS-VIEW {:startkey      [..id.. ..rel..]
-                                                                :endkey        [..id.. ..rel..]
-                                                                :inclusive_end true
-                                                                :reduce        false
-                                                                :include_docs  true}) => [doc1 doc2 doc3]
+                                                                         :endkey        [..id.. ..rel..]
+                                                                         :inclusive_end true
+                                                                         :reduce        false
+                                                                         :include_docs  true}) => [doc1 doc2 doc3]
                            (couch/get-view ..auth.. ..db.. k/LINKS-VIEW {:startkey      [..id.. ..rel.. ..name..]
-                                                                :endkey        [..id.. ..rel.. ..name..]
-                                                                :inclusive_end true
-                                                                :reduce        false
-                                                                :include_docs  true}) => [doc1]
+                                                                         :endkey        [..id.. ..rel.. ..name..]
+                                                                         :inclusive_end true
+                                                                         :reduce        false
+                                                                         :include_docs  true}) => [doc1]
                            (auth/can? anything ::auth/update anything) => true
                            (couch/db ..auth..) => ..db..
                            (auth/authenticated-teams ..auth..) => []
@@ -188,10 +188,10 @@
 
   (facts "`get-links`"
     (against-background [(couch/get-view ..auth.. ..db.. k/LINK-DOCS-VIEW {:startkey      [..id.. ..rel..]
-                                                                  :endkey        [..id.. ..rel..]
-                                                                  :inclusive_end true
-                                                                  :reduce        false
-                                                                  :include_docs  true}) => ..docs..
+                                                                           :endkey        [..id.. ..rel..]
+                                                                           :inclusive_end true
+                                                                           :reduce        false
+                                                                           :include_docs  true}) => ..docs..
                          (couch/db ..auth..) => ..db..
                          (tr/values-from-couch ..docs.. ..auth.. ..rt..) => ..values..]
 


### PR DESCRIPTION
Allows `:delete` on `Relation` documents when authenticated user has
`:write` permission on Relation’s collaboration roots.