### PR TITLE
Revision metadata [Delivers #121750331]

### DIFF
--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -434,7 +434,7 @@
                                        :entity_type   s/Str
                                        :name          s/Str
                                        :owner         s/Uuid
-                                       :updated-at    s/Str
+                                       :updated-at    (s/maybe s/Str) ;; allow nil updated-at
                                        :project_names [s/Str]
                                        :links         {:breadcrumbs s/Str}}]
                      :meta           {:bookmark   s/Str

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -32,7 +32,8 @@
             [buddy.auth.accessrules :refer [wrap-access-rules]]
             [ring.logger.timbre :as logger.timbre]
             [clojure.java.io :as io]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [ovation.revisions :as revisions]))
 
 
 (ovation.logging/setup!)
@@ -316,11 +317,20 @@
               :body [revisions [NewRevision]]
               :summary "Creates a new downstream Revision"
               (created (post-revisions* request id revisions)))
+            (PUT "/update-metadata" request
+              :name :update-metadata
+              :summary "Updates metadata from S3 for this Revision"
+              :return {:revision Revision}
+              (let [auth   (auth/identity request)
+                    rt     (router request)
+                    revision (first (core/get-entities auth [id] rt))]
+                (ok {:revision (revisions/update-metadata auth rt revision)})))
             (context "/links/:rel" []
               :path-params [rel :- s/Str]
 
               (rel-related "Revision" id rel)
               (relationships "Revision" id rel))))
+
 
 
         (context "/prov" []

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -317,9 +317,9 @@
               :body [revisions [NewRevision]]
               :summary "Creates a new downstream Revision"
               (created (post-revisions* request id revisions)))
-            (PUT "/update-metadata" request
-              :name :update-metadata
-              :summary "Updates metadata from S3 for this Revision"
+            (PUT "/upload-complete" request
+              :name :upload-complete
+              :summary "Indicates upload is complete and updates metadata from S3 for this Revision"
               :return {:revision Revision}
               (let [auth   (auth/identity request)
                     rt     (router request)

--- a/src/ovation/revisions.clj
+++ b/src/ovation/revisions.clj
@@ -77,3 +77,14 @@
   "Create Rails Resources for each revision and update attributes accordingly"
   [auth revisions]
   (doall (map #(make-resource auth %) revisions)))          ;;TODO this would be much better as core.async channel
+
+
+(defn update-metadata
+  [auth routes revision]
+  (let [resp (http/get (util/join-path [config/RESOURCES_SERVER (:_id revision) "metadata"])
+               {:oauth-token (::auth/token auth)
+                :headers {"Content-Type" "application/json"}})
+        body (dissoc (util/from-json (:body @resp)) :etag) ;; Remove the :etag entry, since it's not useful to end user
+        updated-revision (update-in revision [:attributes] merge body)]
+    (first (core/update-entities auth [updated-revision] routes))))
+

--- a/src/ovation/routes.clj
+++ b/src/ovation/routes.clj
@@ -33,6 +33,10 @@
   [rt doc]
   (rt :file-head-revisions {:id (:_id doc)}))
 
+(defn upload-complete-route
+  [rt doc]
+  (rt :upload-complete {:id (:_id doc)}))
+
 (defn annotations-route
   [rt doc annotation-type]
   (rt (keyword (format "get-%s" annotation-type)) {:id (:_id doc)}))

--- a/src/ovation/transform/read.clj
+++ b/src/ovation/transform/read.clj
@@ -47,6 +47,12 @@
     (assoc-in dto [:links :heads] (r/heads-route rt dto))
     dto))
 
+(defn add-upload-complete-link
+  [dto rt]
+  (if (= (util/entity-type-keyword dto) (util/entity-type-name-keyword k/REVISION-TYPE))
+    (assoc-in dto [:links :upload-complete] (r/upload-complete-route rt dto))
+    dto))
+
 (defn add-self-link
   "Adds self link to dto"
   [dto rt]
@@ -91,6 +97,7 @@
           (dissoc :relationships)
           (add-self-link router)
           (add-heads-link router)
+          (add-upload-complete-link router)
           (add-annotation-links router)
           (add-relationship-links router)
           (assoc-in [:links :_collaboration_roots] collaboration-roots)

--- a/test/ovation/test/revisions.clj
+++ b/test/ovation/test/revisions.clj
@@ -122,6 +122,20 @@
             (core/get-entities ..auth.. [..revid1.. ..revid2..] ..rt..) => [..rev1.. ..rev2..]))))
 
     (facts "Rails Resources"
+      (facts "update-metadata"
+        (fact "updates metadata from Rails"
+          (let [revision {:_id ..id..}
+                length 100
+                etag "etag"]
+            (with-fake-http [{:url (util/join-path [config/RESOURCES_SERVER ..id.. "metadata"]) :method :get} (fn [orig-fn opts callback]
+                                                                                                                  {:status  200
+                                                                                                                   :body (util/to-json {:content_length length
+                                                                                                                                        :etag           etag})})]
+              (rev/update-metadata ..auth.. ..rt.. revision) => ..result..
+              (provided
+                (core/update-entities ..auth.. [(assoc-in revision [:attributes :content_length] length)] ..rt..) => [..result..])))))
+
+
       (facts "`make-resource`"
         (fact "creates a Rails Resource"
           (let [revid "revid"]


### PR DESCRIPTION
- Adds `upload-complete` handler for a  `Revision`. Adds `content_length`, `version_id` attributes to `Revision`
- Adds `upload-complete` URL to Revision `links`