### PR TITLE
Fix upload status [#121194783]

### DIFF
--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -327,7 +327,7 @@
               :return {:revision Revision}
               (let [auth   (auth/identity request)
                     rt     (router request)
-                    revision (first (core/get-entities auth [id] rt))]
+                    revision (core/get-entity auth id rt)]
                 (ok {:revision (revisions/update-metadata auth rt revision)})))
             (PUT "/upload-failed" request
               :name :upload-failed

--- a/src/ovation/revisions.clj
+++ b/src/ovation/revisions.clj
@@ -117,15 +117,15 @@
                              [updated-revision (update-file-status @file [revision] k/COMPLETE)]
                              [updated-revision])]
       (first (filter #(= (:_id %) (:_id revision))
-               (core/update-entities auth updates routes))))))
+               (core/update-entities auth updates routes :direct true))))))
 
 
-(defn record-upload-failure
+(defn-traced record-upload-failure
   [auth routes revision]
   (let [file-id          (get-in revision [:attributes :file_id])
         file             (core/get-entity auth file-id routes)
         updated-file     (update-file-status file [revision] k/ERROR)
         updated-revision (assoc-in revision [:attributes :upload-status] k/ERROR)
-        updates          (core/update-entities auth [updated-revision updated-file] routes)]
+        updates          (core/update-entities auth [updated-revision updated-file] routes :direct true)]
     {:revision (first (filter #(= (:_id %) (:_id revision)) updates))
      :file     (first (filter #(= (:_id %) (:_id file)) updates))}))

--- a/src/ovation/schema.clj
+++ b/src/ovation/schema.clj
@@ -163,9 +163,9 @@
                          (assoc :type (s/eq "File"))))
 (s/defschema File (-> Entity
                     (assoc :type (s/eq "File"))
-                    (assoc (s/optional-key :revisions) [{:_id                    s/Uuid
-                                                         :status                 (s/enum k/UPLOADING k/COMPLETE k/ERROR)
-                                                         (s/optional-key :error) s/Str}])))
+                    (assoc (s/optional-key :revisions) {s/Uuid {:status                 (s/enum k/UPLOADING k/COMPLETE k/ERROR)
+                                                               :started-at             s/Str
+                                                               (s/optional-key :error) s/Str}})))
 
 (s/defschema FileUpdate (-> EntityUpdate
                             (assoc :type (s/eq "File"))))

--- a/src/ovation/transform/read.clj
+++ b/src/ovation/transform/read.clj
@@ -92,7 +92,14 @@
     (assoc-in [:permissions :update] (auth/can? auth ::auth/update doc))
     (assoc-in [:permissions :delete] (auth/can? auth ::auth/delete doc))))
 
-(defn-traced couch-to-entity
+(defn convert-file-revision-status
+  [doc]
+  (if (= (:type doc) k/FILE-TYPE)
+    (let [revisions (into {} (map (fn [[k,v]] [(name k) v]) (:revisions doc)))]
+      (assoc doc :revisions revisions))
+    doc))
+
+(defn couch-to-entity
   [auth router & {:keys [teams] :or {teams nil}}]
   (fn [doc]
     (case (:error doc)
@@ -111,6 +118,7 @@
           (add-zip-link router)
           (add-annotation-links router)
           (add-relationship-links router)
+          (convert-file-revision-status)
           (assoc-in [:links :_collaboration_roots] collaboration-roots)
           (add-entity-permissions auth teams))))))
 

--- a/test/ovation/test/revisions.clj
+++ b/test/ovation/test/revisions.clj
@@ -162,7 +162,7 @@
             (provided
               (rev/update-file-status file [revision] k/COMPLETE) => ..updated-file..
               (core/get-entity ..auth.. ..fileid.. ..rt..) => file
-              (core/update-entities ..auth.. [updated-rev ..updated-file..] ..rt..) => [{:_id ..id.. :result true} {:_id ..fileid..}])))))
+              (core/update-entities ..auth.. [updated-rev ..updated-file..] ..rt.. :direct true) => [{:_id ..id.. :result true} {:_id ..fileid..}])))))
 
 
     (facts "record-upload-failure"
@@ -178,7 +178,7 @@
                                                               :file     updated-file}
           (provided
             (core/get-entity ..auth.. ..fileid.. ..rt..) => file
-            (core/update-entities ..auth.. [updated-revision updated-file] ..rt..) => [updated-revision updated-file]))))
+            (core/update-entities ..auth.. [updated-revision updated-file] ..rt.. :direct true) => [updated-revision updated-file]))))
 
 
     (facts "make-resource"


### PR DESCRIPTION
Direct updates allow setting of File `:revisions`. Also, we have to
de-keywordize the revision IDs in `:revisions`.