### PR TITLE
Create and Update with organizations [Delivers #136273291]

### DIFF
--- a/src/ovation/core.clj
+++ b/src/ovation/core.clj
@@ -75,7 +75,7 @@
 
   (let [{auth ::rc/auth} ctx
         created-entities (tr/entities-from-couch (couch/bulk-docs db
-                                                   (tw/to-couch (auth/authenticated-user-id auth)
+                                                   (tw/to-couch ctx
                                                      entities
                                                      :collaboration_roots (parent-collaboration-roots ctx db parent)))
                            ctx)]
@@ -136,7 +136,7 @@
                                 merge-fn (merge-updates-fn entities :update-collaboration-roots update-collaboration-roots :allow-keys allow-keys)]
                             (map merge-fn docs))
         auth-checked-docs (if authorize (doall (map (auth/check! auth ::auth/update) bulk-docs)) bulk-docs)]
-    (tr/entities-from-couch (couch/bulk-docs db (tw/to-couch (auth/authenticated-user-id auth) auth-checked-docs))
+    (tr/entities-from-couch (couch/bulk-docs db (tw/to-couch ctx auth-checked-docs))
       ctx)))
 
 (defn-traced trash-entity
@@ -159,7 +159,7 @@
         user-id           (auth/authenticated-user-id auth)
         trashed           (map #(restore-trashed-entity user-id %) docs)
         auth-checked-docs (vec (map (auth/check! auth ::auth/update) trashed))]
-    (tr/entities-from-couch (couch/bulk-docs db (tw/to-couch (auth/authenticated-user-id auth) auth-checked-docs))
+    (tr/entities-from-couch (couch/bulk-docs db (tw/to-couch ctx auth-checked-docs))
       ctx)))
 
 (defn-traced delete-entities
@@ -173,7 +173,7 @@
     (let [user-id (auth/authenticated-user-id auth)
           trashed (map #(trash-entity user-id %) docs)
           auth-checked-docs (vec (map (auth/check! auth ::auth/delete) trashed))]
-      (tr/entities-from-couch (couch/bulk-docs db (tw/to-couch (auth/authenticated-user-id auth) auth-checked-docs))
+      (tr/entities-from-couch (couch/bulk-docs db (tw/to-couch ctx auth-checked-docs))
                               ctx))))
 
 

--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -116,10 +116,9 @@
         entities-map (util/into-id-map entities)]
     (mapcat (fn [[id relationships]]
               (map (fn [[rel info]]
-                     (let [org (-> (entities-map id) :organization)]
-                       (if (:create_as_inverse info)
-                         (links/add-links ctx db (core/get-entities ctx db (:related info)) (:inverse_rel info) [id] :inverse-rel rel)
-                         (links/add-links ctx db [(get entities-map id)] rel (:related info) :inverse-rel (:inverse_rel info)))))
+                     (if (:create_as_inverse info)
+                       (links/add-links ctx db (core/get-entities ctx db (:related info)) (:inverse_rel info) [id] :inverse-rel rel)
+                       (links/add-links ctx db [(get entities-map id)] rel (:related info) :inverse-rel (:inverse_rel info))))
                 relationships))
       rel-map)))
 

--- a/src/ovation/schema.clj
+++ b/src/ovation/schema.clj
@@ -75,14 +75,12 @@
 ;; -- ENTITIES -- ;;
 
 (s/defschema NewEntity {:type       s/Str
-                        :attributes {s/Keyword s/Any}
-                        (s/optional-key :organization) (s/either s/Int s/Str)})
+                        :attributes {s/Keyword s/Any}})
 
 (s/defschema BaseEntity (assoc NewEntity :_rev s/Str
                                          :_id s/Uuid
                                          (s/optional-key :api_version) s/Int
-                                         (s/optional-key :permissions) {s/Keyword s/Bool}
-                                         (s/optional-key :organization) (s/either s/Int s/Str)))
+                                         (s/optional-key :permissions) {s/Keyword s/Bool}))
 
 
 (s/defschema Entity (assoc BaseEntity

--- a/src/ovation/teams.clj
+++ b/src/ovation/teams.clj
@@ -67,8 +67,7 @@
 
 (defn get-team*
   [ctx team-id]
-  (let [{rt ::rc/routes} ctx
-        opts (request-opts (rc/token ctx))
+  (let [opts (request-opts (rc/token ctx))
         url (make-url "teams" team-id)
         response @(httpkit.client/get url opts)]
 
@@ -93,8 +92,7 @@
 
 (defn- put-membership
   [ctx team-uuid membership membership-id pending?]                              ;; membership is a TeamMembership
-  (let [rt (::rc/routes ctx)
-        url-path (if pending? "pending_memberships" "memberships")
+  (let [url-path (if pending? "pending_memberships" "memberships")
         opts (request-opts (rc/token ctx))
         url (make-url url-path membership-id)
         role-id (get-in membership [:role :id])

--- a/src/ovation/transform/read.clj
+++ b/src/ovation/transform/read.clj
@@ -113,6 +113,7 @@
             (dissoc :named_links)                           ;; For v3
             (dissoc :links)                                 ;; For v3
             (dissoc :relationships)
+            (dissoc :organization)
             (add-self-link ctx)
             (add-heads-link ctx)
             (add-upload-links ctx)
@@ -151,10 +152,12 @@
         "unauthorized" (unauthorized!)
         (condp = (util/entity-type-name doc)
           c/RELATION-TYPE-NAME (-> doc
+                                 (dissoc :organization)
                                  (add-self-link ctx))
           ;(add-value-permissions auth)
 
           c/ANNOTATION-TYPE-NAME (-> doc
+                                   (dissoc :organization)
                                    (add-annotation-self-link ctx)
                                    (add-value-permissions auth))
 

--- a/src/ovation/transform/read.clj
+++ b/src/ovation/transform/read.clj
@@ -163,6 +163,7 @@
 
           ;; default
           (-> doc
+            (dissoc :organization)
             (add-value-permissions auth)))))))
 
 (defn-traced values-from-couch

--- a/test/ovation/test/core.clj
+++ b/test/ovation/test/core.clj
@@ -120,7 +120,7 @@
         (fact "it throws unauthorized exception if any :type is User"
           (core/create-entities ..ctx.. ..db.. [(assoc new-entity :type "User")]) => (throws Exception))
 
-        (against-background [(tw/to-couch ..owner-id.. [{:type       type
+        (against-background [(tw/to-couch ..ctx.. [{:type       type
                                                          :attributes attributes}]
                                :collaboration_roots []) => [..doc..]
                              (auth/authenticated-user-id ..auth..) => ..owner-id..
@@ -137,7 +137,7 @@
               (provided
                 (tr/entities-from-couch ..result.. ..ctx..) => ..result..
                 (core/parent-collaboration-roots ..ctx.. ..db.. ..parent..) => ..collaboration_roots..
-                (tw/to-couch ..owner-id.. [{:type       type
+                (tw/to-couch ..ctx.. [{:type       type
                                             :attributes attributes}]
                   :collaboration_roots ..collaboration_roots..) => [..doc..])))
 
@@ -151,7 +151,7 @@
                                                      :attributes attributes}] :parent nil) => [{:type "Project"
                                                                                                 :_id  ..id..}]
               (provided
-                (tw/to-couch ..owner-id.. [{:type       "Project"
+                (tw/to-couch ..ctx.. [{:type       "Project"
                                             :attributes attributes}]
                   :collaboration_roots []) => [..doc..]
                 (tr/entities-from-couch ..result.. ..ctx..) => [{:type "Project"
@@ -174,8 +174,8 @@
                              (assoc-in [:attributes :foo] ..foo..))
             updated-entity (-> entity
                              (assoc :_rev rev2))]
-        (against-background [(tw/to-couch ..owner-id.. [new-entity] :collaboration_roots nil) => [..doc..]
-                             (tw/to-couch ..owner-id.. [update]) => [update]
+        (against-background [(tw/to-couch ..ctx.. [new-entity] :collaboration_roots nil) => [..doc..]
+                             (tw/to-couch ..ctx.. [update]) => [update]
                              (auth/authenticated-user-id ..auth..) => ..owner-id..
                              (couch/bulk-docs ..db.. [..doc..]) => [entity]
                              (core/get-entities ..ctx.. ..db.. [id]) => [entity]
@@ -192,7 +192,7 @@
               (provided
                 (auth/can? ..auth.. ::auth/update anything) => true
                 (couch/bulk-docs ..db.. [update-with-revs]) => [updated-entity-with-revs]
-                (tw/to-couch ..owner-id.. [update-with-revs]) => [update-with-revs]
+                (tw/to-couch ..ctx.. [update-with-revs]) => [update-with-revs]
                 (tr/entities-from-couch [updated-entity-with-revs] ..ctx..) => [updated-entity-with-revs])))
           (fact "it updates collaboration roots"
             (let [update2         (-> update
@@ -201,7 +201,7 @@
               (core/update-entities ..ctx.. ..db.. [update2] :update-collaboration-roots true) => [updated-entity2]
               (provided
                 (auth/can? ..auth.. ::auth/update anything) => true
-                (tw/to-couch ..owner-id.. [update2]) => [update2]
+                (tw/to-couch ..ctx.. [update2]) => [update2]
                 (couch/bulk-docs ..db.. [update2]) => [updated-entity2]
                 (tr/entities-from-couch [updated-entity2] ..ctx..) => [updated-entity2])))
 
@@ -232,7 +232,7 @@
         (provided
           (auth/authenticated-user-id ..auth..) => ..owner..
           (core/get-entities ..ctx.. ..db.. [id] :include-trashed true) => [entity]
-          (tw/to-couch ..owner.. [restored]) => ..couch-docs..
+          (tw/to-couch ..ctx.. [restored]) => ..couch-docs..
           (couch/bulk-docs ..db.. ..couch-docs..) => ..restored..
           (tr/entities-from-couch ..restored.. ..ctx..) => ..result..
           (auth/can? ..auth.. ::auth/update restored) => true)))
@@ -251,7 +251,7 @@
         (against-background [(auth/authenticated-user-id ..auth..) => ..owner-id..]
 
           (against-background [(core/get-entities ..ctx.. ..db.. [id]) => [entity]
-                               (tw/to-couch ..owner-id.. [update]) => ..update-docs..
+                               (tw/to-couch ..ctx.. [update]) => ..update-docs..
                                (couch/bulk-docs ..db.. ..update-docs..) => ..deleted..
                                (tr/entities-from-couch ..deleted.. ..ctx..) => ..result..
                                (util/iso-now) => ..date..]

--- a/test/ovation/test/revisions.clj
+++ b/test/ovation/test/revisions.clj
@@ -55,8 +55,7 @@
                 rev          {:_id  ..revid..
                               :_rev ..revrev..}
                 file         {:_id          ..rsrcid..
-                              :type         k/FILE-TYPE
-                              :organization ..org..}]
+                              :type         k/FILE-TYPE}]
             (rev/create-revisions ..ctx.. ..db.. ..parent.. [new-revision]) => {:revisions [rev]
                                                                                 :links     ..links..
                                                                                 :updates   []}
@@ -64,8 +63,7 @@
               ..parent.. =contains=> {:type         k/REVISION-TYPE
                                       :_id          ..previd..
                                       :attributes   {:file_id  ..rsrcid..
-                                                     :previous [..oldprev..]}
-                                      :organization ..org..}
+                                                     :previous [..oldprev..]}}
               (core/create-entities ..ctx.. ..db.. [{:type       "Revision"
                                                      :attributes {:previous [..oldprev.. ..previd..]
                                                                   :file_id  ..rsrcid..}}]) => [rev]
@@ -90,8 +88,7 @@
               (provided
                 ..file.. =contains=> {:type         k/FILE-TYPE
                                       :_id          ..fileid..
-                                      :attributes   {}
-                                      :organization ..org..}
+                                      :attributes   {}}
                 (rev/get-head-revisions ..ctx.. ..db.. ..file..) => [{:type       k/REVISION-TYPE
                                                                       :_id        ..headid..
                                                                       :attributes {:previous []
@@ -117,8 +114,7 @@
               (provided
                 ..file.. =contains=> {:type         k/FILE-TYPE
                                       :_id          ..fileid..
-                                      :attributes   {}
-                                      :organization ..org..}
+                                      :attributes   {}}
                 (rev/get-head-revisions ..ctx.. ..db.. ..file..) => []
                 (core/create-entities ..ctx.. ..db.. [{:type       "Revision"
                                                        :attributes {:previous [] ;; <- this is key

--- a/test/ovation/test/route_helpers.clj
+++ b/test/ovation/test/route_helpers.clj
@@ -41,19 +41,16 @@
 
   (facts "About post-resource*"
     (fact "adds embedded relationships"
-      (let [project      {:type         k/PROJECT-TYPE
-                          :_id          ..projectid..
-                          :organization ..org..}
-            rev          {:type         k/REVISION-TYPE
-                          :_id          ..revid..
-                          :organization ..org..}
+      (let [project      {:type k/PROJECT-TYPE
+                          :_id  ..projectid..}
+            rev          {:type k/REVISION-TYPE
+                          :_id  ..revid..}
             new-activity {:type          k/ACTIVITY-TYPE
                           :relationships {:inputs {:related     [(:_id rev)]
                                                    :type        k/REVISION-TYPE
                                                    :inverse_rel :activities}}}
             activity     (-> new-activity
-                           (assoc :_id (util/make-uuid))
-                           (assoc :organization ..org..))]
+                           (assoc :_id (util/make-uuid)))]
         (:body (r/post-resource* ..ctx.. ..db.. k/PROJECT-TYPE ..projectid.. [new-activity])) => {:entities [activity]
                                                                                                   :links    ..links..
                                                                                                   :updates  ..updates..}
@@ -70,17 +67,15 @@
 
 
     (fact "handles embedded relationships with :create_as_inverse == true"
-      (let [project      {:type         k/PROJECT-TYPE
-                          :_id          ..projectid..
-                          :organization ..org..}
+      (let [project      {:type k/PROJECT-TYPE
+                          :_id  ..projectid..}
             new-activity {:type          k/ACTIVITY-TYPE
                           :relationships {:parents {:related           [(:_id project)]
                                                     :type              k/PROJECT-TYPE
                                                     :inverse_rel       :activities
                                                     :create_as_inverse true}}}
             activity     (-> new-activity
-                           (assoc :_id (util/make-uuid))
-                           (assoc :organization ..org..))]
+                           (assoc :_id (util/make-uuid)))]
         (:body (r/post-resource* ..ctx.. ..db.. k/PROJECT-TYPE ..projectid.. [new-activity])) => {:entities [activity]
                                                                                                   :links    ..links..
                                                                                                   :updates  ..updates..}
@@ -97,12 +92,10 @@
           (core/update-entities ..ctx.. ..db.. anything :authorize false :update-collaboration-roots true) => ..updates..)))
 
     (fact "adds relationships for a new Source"
-      (let [source-entity {:type         "Source"
-                           :_id          ..id2..
-                           :organization ..org..}
-            file-entity   {:type         "File"
-                           :_id          ..fileid..
-                           :organization ..org..}]
+      (let [source-entity {:type "Source"
+                           :_id  ..id2..}
+            file-entity   {:type "File"
+                           :_id  ..fileid..}]
         (:body (r/post-resource* ..ctx.. ..db.. "file" ..fileid.. [{:type       "Source"
                                                                     :attributes {}}])) => {:entities (seq [source-entity])
                                                                                            :links    ..links..
@@ -116,15 +109,12 @@
 
   (facts "About move-file*"
     (fact "fails if entity not file or folder"
-      (let [src  {:type         "Folder"
-                  :_id          ..src..
-                  :organization ..org..}
-            file {:type         "Whoa"
-                  :_id          ..file..
-                  :organization ..org..}
-            dest {:type         "Folder"
-                  :_id          ..dest..
-                  :organization ..org..}]
+      (let [src  {:type "Folder"
+                  :_id  ..src..}
+            file {:type "Whoa"
+                  :_id  ..file..}
+            dest {:type "Folder"
+                  :_id  ..dest..}]
 
         (r/move-contents* ..req.. ..db.. ..org.. ..file.. {:source ..src.. :destination ..dest..}) => (throws ExceptionInfo)
         (provided
@@ -133,15 +123,12 @@
           (core/get-entities ..ctx.. ..db.. [..file..]) => (seq [file]))))
 
     (fact "fails if src not a folder"
-      (let [src  {:type         "Whoa"
-                  :_id          ..src..
-                  :organization ..org..}
-            file {:type         "File"
-                  :_id          ..file..
-                  :organization ..org..}
-            dest {:type         "Folder"
-                  :_id          ..dest..
-                  :organization ..org..}]
+      (let [src  {:type "Whoa"
+                  :_id  ..src..}
+            file {:type "File"
+                  :_id  ..file..}
+            dest {:type "Folder"
+                  :_id  ..dest..}]
 
         (r/move-contents* ..req.. ..db.. ..org.. ..file.. {:source ..src.. :destination ..dest..}) => (throws ExceptionInfo)
         (provided
@@ -150,15 +137,12 @@
           (core/get-entities ..ctx. ..db.. [..file..]) => (seq [file]))))
 
     (fact "fails if dest not a folder"
-      (let [src  {:type         "Folder"
-                  :_id          ..src..
-                  :organization ..org..}
-            file {:type         "File"
-                  :_id          ..file..
-                  :organization ..org..}
-            dest {:type         "Whoa"
-                  :_id          ..dest..
-                  :organization ..org..}]
+      (let [src  {:type "Folder"
+                  :_id  ..src..}
+            file {:type "File"
+                  :_id  ..file..}
+            dest {:type "Whoa"
+                  :_id  ..dest..}]
 
         (r/move-contents* ..req.. ..db.. ..org.. ..file.. {:source ..src.. :destination ..dest..}) => (throws ExceptionInfo)
         (provided
@@ -169,13 +153,13 @@
     (fact "adds relationships"
       (let [src  {:type         "Folder"
                   :_id          ..src..
-                  :organization ..org..}
+                  }
             file {:type         "File"
                   :_id          ..file..
-                  :organization ..org..}
+                  }
             dest {:type         "Folder"
                   :_id          ..dest..
-                  :organization ..org..}]
+                  }]
 
         (r/move-contents* ..req.. ..db.. ..org.. ..file.. {:source ..src.. :destination ..dest..}) => {:file    file
                                                                                                        :links   ..created-links..

--- a/test/ovation/test/transform.clj
+++ b/test/ovation/test/transform.clj
@@ -176,6 +176,13 @@
       (let [doc {:type ..type.. :attributes {:label ..label..}}]
         (tw/ensure-owner doc ..owner..) => (assoc doc :owner ..owner..))))
 
+  (facts "About add-organization"
+    (fact "adds organization from request context"
+      (let [doc {:type ..type.. :attributes {:label ..value..}}]
+        (tw/add-organization doc ..ctx..) => (assoc doc :organization ..org..)
+        (provided
+          ..ctx.. =contains=> {::request-context/org ..org..}))))
+
   (facts "About `remove-user-attributes`"
     (fact "Removes User entity attributes"
       (let [user {:type "User" :attributes {:password ..secret..}}]


### PR DESCRIPTION
Allows POST/PUT with organizations.

Organization ID is confined to the Cloudant layer. It’s stripped on read, and replaced on write.