### PR TITLE
Check authenticated organization Check authenticated organizations [Delivers #142721103]

### DIFF
--- a/src/ovation/links.clj
+++ b/src/ovation/links.clj
@@ -179,9 +179,9 @@
 
 (defn-traced delete-links
   ([ctx db doc rel target-id & {:keys [name] :or [name nil]}]
-   (auth/check! (::request-context/auth ctx) ::auth/update doc)
+   (auth/check! ctx ::auth/update doc)
    (let [link-id (link-id (:_id doc) rel target-id :name name)]
      (core/delete-values ctx db [link-id])))
   ([ctx db doc link-id]
-   (auth/check! (::request-context/auth ctx) ::auth/update doc)
+   (auth/check! ctx ::auth/update doc)
    (core/delete-values ctx db [link-id])))

--- a/src/ovation/middleware/auth.clj
+++ b/src/ovation/middleware/auth.clj
@@ -12,6 +12,6 @@
     (if (auth/authenticated? request)
       (-> request
         (assoc-in [:identity ::auth/authenticated-teams] (teams/get-teams (auth/token request)))
-        (assoc-in [:identity ::auth/authenticated-permissions] (auth/permissions (auth/token request)))
+        (assoc-in [:identity ::auth/authenticated-permissions] (auth/get-permissions (auth/token request)))
         (handler))
       (handler request))))

--- a/src/ovation/request_context.clj
+++ b/src/ovation/request_context.clj
@@ -6,7 +6,8 @@
 (defprotocol AuthToken
   (token [this])
   (team-ids [this])
-  (user-id [this]))
+  (user-id [this])
+  (organization-ids [this]))
 
 (defrecord RequestContext
   [auth org routes query-params]
@@ -17,7 +18,9 @@
   (team-ids [c]
     (auth/authenticated-teams (::auth c)))
   (user-id [c]
-    (auth/authenticated-user-id (::auth c))))
+    (auth/authenticated-user-id (::auth c)))
+  (organization-ids [c]
+    (auth/organization-ids (::request c))))
 
 (defn router
   [request]

--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -312,10 +312,9 @@
 (defn-traced post-relationships*
   [ctx db id new-links rel]
   (try+
-    (let [{auth   ::request-context/auth} ctx
-          source (first (core/get-entities ctx db [id]))]
+    (let [source (first (core/get-entities ctx db [id]))]
       (when source
-        (auth/check! auth ::auth/update source))
+        (auth/check! ctx ::auth/update source))
       (if source
         (let [groups      (group-by :inverse_rel new-links)
               link-groups (map (fn [[irel nlinks]] (links/add-links ctx db [source] rel (map :target_id nlinks) :inverse-rel irel)) (seq groups))]

--- a/test/ovation/test/auth.clj
+++ b/test/ovation/test/auth.clj
@@ -3,6 +3,7 @@
   (:require [ovation.auth :as auth]
             [ovation.teams :as teams]
             [clojure.core.async :as async :refer [>!!]]
+            [ovation.request-context :as request-context]
             [org.httpkit.fake :refer [with-fake-http]]
             [clojure.data.codec.base64 :as b64]
             [ovation.util :as util]
@@ -27,81 +28,83 @@
 (facts "About `can?`"
   (facts ":read"
     (against-background [(auth/authenticated-user-id ..auth..) => ..user..
-                         (auth/authenticated-teams ..auth..) => [..team1.. ..team2..]]
+                         (auth/authenticated-teams ..auth..) => [..team1.. ..team2..]
+                         ..ctx.. =contains=> {::request-context/auth ..auth..}]
       (facts "entities"
         (fact "allowed when user is owner"
-          (auth/can? ..auth.. ::auth/read {:type "Project"
+          (auth/can? ..ctx.. ::auth/read {:type   "Project"
                                            :owner ..user..}) => true)
         (fact "allowed when one of authenticated user's teams in collaboration roots"
-          (auth/can? ..auth.. ::auth/read {:type "File"
+          (auth/can? ..ctx.. ::auth/read {:type   "File"
                                            :owner ..other..
                                            :links {:_collaboration_roots [..team1.. ..team3..]}}) => true)
         (fact "allowed when all of authenticated user's teams in collaboration roots"
-          (auth/can? ..auth.. ::auth/read {:type "File"
+          (auth/can? ..ctx.. ::auth/read {:type   "File"
                                            :owner ..other..
                                            :links {:_collaboration_roots [..team1.. ..team2..]}}) => true)
 
         (fact "not allowed when not owner or team member"
-          (auth/can? ..auth.. ::auth/read {:type "File"
+          (auth/can? ..ctx.. ::auth/read {:type   "File"
                                            :owner ..other..
                                            :links {:_collaboration_roots [..team3..]}}) => false)
 
         (fact "not allowed when not owner"
-          (auth/can? ..auth.. ::auth/read {:type "File"
+          (auth/can? ..ctx.. ::auth/read {:type   "File"
                                            :owner ..other..
                                            :links {:_collaboration_roots []}}) => false))
 
       (facts "annotations"
         (fact "not allowed when not owner"
-          (auth/can? ..auth.. ::auth/read {:type "Annotation"
-                                           :user ..other..
+          (auth/can? ..ctx.. ::auth/read {:type    "Annotation"
+                                           :user   ..other..
                                            :entity ..id..
-                                           :links {:_collaboration_roots []}}) => false)
+                                           :links  {:_collaboration_roots []}}) => false)
         (fact "not allowed when none of authenticated user's teams in collaboration roots"
-          (auth/can? ..auth.. ::auth/read {:type "Annotation"
-                                           :user ..other..
+          (auth/can? ..ctx.. ::auth/read {:type    "Annotation"
+                                           :user   ..other..
                                            :entity ..id..
-                                           :links {:_collaboration_roots [..team3..]}}) => false)
+                                           :links  {:_collaboration_roots [..team3..]}}) => false)
         (fact "allowed when user is :user"
-          (auth/can? ..auth.. ::auth/read {:type "Annotation"
-                                           :user ..user..
+          (auth/can? ..ctx.. ::auth/read {:type    "Annotation"
+                                           :user   ..user..
                                            :entity ..id..}) => true)
         (fact "allowed when one of authenticated user's teams in collaboration roots"
-          (auth/can? ..auth.. ::auth/read {:type "Annotation"
-                                           :user ..other..
+          (auth/can? ..ctx.. ::auth/read {:type    "Annotation"
+                                           :user   ..other..
                                            :entity ..id..
-                                           :links {:_collaboration_roots [..team1.. ..team3..]}}) => true)
+                                           :links  {:_collaboration_roots [..team1.. ..team3..]}}) => true)
         (fact "allowed when all of authenticated user's teams in collaboration roots"
-          (auth/can? ..auth.. ::auth/read {:type "Annotation"
-                                           :user ..other..
+          (auth/can? ..ctx.. ::auth/read {:type    "Annotation"
+                                           :user   ..other..
                                            :entity ..id..
-                                           :links {:_collaboration_roots [..team1.. ..team2..]}}) => true))
+                                           :links  {:_collaboration_roots [..team1.. ..team2..]}}) => true))
       (facts "relationships"
         (fact "not allowed when user is not :user"
-          (auth/can? ..auth.. ::auth/read {:type "Relation"
+          (auth/can? ..ctx.. ::auth/read {:type     "Relation"
                                            :user_id ..other..}) => false)
         (fact "not allowed when user is not user or team member"
-          (auth/can? ..auth.. ::auth/read {:type "Relation"
+          (auth/can? ..ctx.. ::auth/read {:type     "Relation"
                                            :user_id ..other..
-                                           :links {:_collaboration_roots [..team3..]}}) => false)
+                                           :links   {:_collaboration_roots [..team3..]}}) => false)
         (fact "allowed when user is :user"
-          (auth/can? ..auth.. ::auth/read {:type "Relation"
+          (auth/can? ..ctx.. ::auth/read {:type     "Relation"
                                            :user_id ..user..}) => true)
         (fact "allowed when one of authenticated user's teams in collaboration roots"
-          (auth/can? ..auth.. ::auth/read {:type "Relation"
+          (auth/can? ..ctx.. ::auth/read {:type     "Relation"
                                            :user_id ..user..
-                                           :links {:_collaboration_roots [..team1.. ..team3..]}}) => true)
+                                           :links   {:_collaboration_roots [..team1.. ..team3..]}}) => true)
         (fact "allowed when all of authenticated user's teams in collaboration roots"
-          (auth/can? ..auth.. ::auth/read {:type "Relation"
+          (auth/can? ..ctx.. ::auth/read {:type     "Relation"
                                            :user_id ..user..
-                                           :links {:_collaboration_roots [..team1.. ..team2..]}}) => true))))
+                                           :links   {:_collaboration_roots [..team1.. ..team2..]}}) => true))))
 
   (facts ":create"
-    (against-background [(auth/authenticated-user-id ..auth..) => ..user..]
+    (against-background [(auth/authenticated-user-id ..auth..) => ..user..
+                         ..ctx.. =contains=> {::request-context/auth ..auth..}]
       (facts "Annotations"
         (fact "allowed when :user is authenticated user and can read all roots"
-          (auth/can? ..auth.. ::auth/create {:type "Annotation"
-                                             :user ..user..
+          (auth/can? ..ctx.. ::auth/create {:type    "Annotation"
+                                             :user   ..user..
                                              :entity ..id..}) => true)
           ;(provided
           ;  (auth/get-permissions ..auth.. [..id..]) => ..permissions..
@@ -109,12 +112,12 @@
 
 
         (fact "denied when :user is not authenticated user but can read all roots"
-          (auth/can? ..auth.. ::auth/create {:type "Annotation"
-                                             :user ..other..
+          (auth/can? ..ctx.. ::auth/create {:type    "Annotation"
+                                             :user   ..other..
                                              :entity ..id..}) => false))
 
         ;(fact "denied when :user is authenticated user but cannot read any roots"
-        ;  (auth/can? ..auth.. ::auth/create {:type "Annotation"
+      ;  (auth/can? ..ctx.. ::auth/create {:type "Annotation"
         ;                                     :user ..user..
         ;                                     :entity ..id..}) => false
         ;  (provided
@@ -124,8 +127,8 @@
 
       (facts "Relations"
         (fact "allowed when :user is authenticated user and can read source and target"
-          (auth/can? ..auth.. ::auth/create {:type "Relation"
-                                             :user_id ..user..
+          (auth/can? ..ctx.. ::auth/create {:type       "Relation"
+                                             :user_id   ..user..
                                              :source_id ..src..
                                              :target_id ..target..}) => true))
           ;(provided
@@ -134,7 +137,7 @@
 
 
         ;(fact "denied when :user is authenticated user and cannot read source and target"
-        ;  (auth/can? ..auth.. ::auth/create {:type "Relation"
+      ;  (auth/can? ..ctx.. ::auth/create {:type "Relation"
         ;                                     :user_id ..user..
         ;                                     :source_id ..src..
         ;                                     :target_id ..target..}) => true
@@ -146,58 +149,59 @@
 
       (facts "projects"
         (fact "allow when :owner nil"
-          (auth/can? ..auth.. ::auth/create {:type "Project"
+          (auth/can? ..ctx.. ::auth/create {:type   "Project"
                                              :owner nil}) => true)
         (fact "allow when :owner is current user"
-          (auth/can? ..auth.. ::auth/create {:type "Project"
+          (auth/can? ..ctx.. ::auth/create {:type   "Project"
                                              :owner ..user..}) => true))
 
       (facts "entities"
         (fact "allow when :owner nil and can read all roots"
-          (auth/can? ..auth.. ::auth/create {:type  "Entity"
+          (auth/can? ..ctx.. ::auth/create {:type   "Entity"
                                              :owner nil
                                              :links {:_collaboration_roots [..root..]}}) => true
           (provided
             (auth/authenticated-user-id ..auth..) => ..user..
-            (auth/get-permissions ..auth.. [..root..]) => [{:uuid        ..root..
+            (auth/permissions ..auth.. [..root..]) => [{:uuid            ..root..
                                                             :permissions {:read true}}]))
 
         (fact "denies when :owner nil and cannot read all roots"
-          (auth/can? ..auth.. ::auth/create {:type  "Entity"
+          (auth/can? ..ctx.. ::auth/create {:type   "Entity"
                                              :owner nil
                                              :links {:_collaboration_roots [..root..]}}) => falsey
           (provided
-            (auth/get-permissions ..auth.. [..root..]) => [{:uuid        ..root..
+            (auth/permissions ..auth.. [..root..]) => [{:uuid            ..root..
                                                             :permissions {:read false}}
                                                            {:uuid        ..root2..
                                                             :permissions {:read true}}]))
 
 
         (fact "allows when :owner is auth user and can read all roots"
-          (auth/can? ..auth.. ::auth/create {:type  "Entity"
+          (auth/can? ..ctx.. ::auth/create {:type   "Entity"
                                              :owner ..user..
                                              :links {:_collaboration_roots [..root..]}}) => true
           (provided
-            (auth/get-permissions ..auth.. [..root..]) => ..permissions..
+            (auth/permissions ..auth.. [..root..]) => ..permissions..
             (auth/collect-permissions ..permissions.. :read) => [true]))
 
         (fact "denies when :owner is auth user and cannot read all roots"
-          (auth/can? ..auth.. ::auth/create {:type  "Entity"
+          (auth/can? ..ctx.. ::auth/create {:type   "Entity"
                                              :owner ..user..
                                              :links {:_collaboration_roots [..root..]}}) => false
           (provided
             (auth/authenticated-user-id ..auth..) => ..user..
-            (auth/get-permissions ..auth.. [..root..]) => ..permissions..
+            (auth/permissions ..auth.. [..root..]) => ..permissions..
             (auth/collect-permissions ..permissions.. :read) => [true false])))))
 
   (facts ":update"
-    (against-background [(auth/authenticated-user-id ..auth..) => (str (UUID/randomUUID))]
+    (against-background [(auth/authenticated-user-id ..auth..) => (str (UUID/randomUUID))
+                         ..ctx.. =contains=> {::request-context/auth ..auth..}]
       (fact "Delegates to get-permissions when not owner"
-        (auth/can? ..auth.. ::auth/update {:type  "Entity"
+        (auth/can? ..ctx.. ::auth/update {:type   "Entity"
                                            :owner (str (UUID/randomUUID))
                                            :links {:_collaboration_roots ..roots..}}) => true
         (provided
-          (auth/get-permissions ..auth.. ..roots..) => [{:uuid        :uuid1
+          (auth/permissions ..auth.. ..roots..) => [{:uuid            :uuid1
                                                          :permissions {:read  true
                                                                        :write false
                                                                        :admin false}}
@@ -206,10 +210,11 @@
                                                                        :write true
                                                                        :admin false}}]))))
   (facts ":delete"
-    (against-background [(auth/authenticated-user-id ..auth..) => ..user..]
+    (against-background [(auth/authenticated-user-id ..auth..) => ..user..
+                         ..ctx.. =contains=> {::request-context/auth ..auth..}]
       (facts "Relations"
         (fact "allowed if user is owner"
-          (auth/can? ..auth.. ::auth/delete {:type k/RELATION-TYPE
+          (auth/can? ..ctx.. ::auth/delete {:type     k/RELATION-TYPE
                                              :user_id ..user..}) => true)
         (fact "allowed if user can admin all collaboration roots"
           (let [doc {:type k/RELATION-TYPE
@@ -217,29 +222,29 @@
                      :source_id ..src..
                      :target_id ..target..
                      :links {:_collaboration_roots ..roots..}}]
-            (auth/can? ..auth.. ::auth/delete doc) => true
+            (auth/can? ..ctx.. ::auth/delete doc) => true
             (provided
-              (auth/get-permissions ..auth.. ..roots..) => ..permissions..
+              (auth/permissions ..auth.. ..roots..) => ..permissions..
               (auth/collect-permissions ..permissions.. :write) => [true true]))))
       (fact "Annoations require :user match authenticated user"
-        (auth/can? ..auth.. ::auth/delete {:type "Annotation"
+        (auth/can? ..ctx.. ::auth/delete {:type  "Annotation"
                                            :user ..user..}) => true
-        (auth/can? ..auth.. ::auth/delete {:type "Annotation"
+        (auth/can? ..ctx.. ::auth/delete {:type  "Annotation"
                                            :user ..other..}) => false)
 
       (fact "allowed when entity :owner is nil"
-        (auth/can? ..auth.. ::auth/delete {:type  "Entity"
+        (auth/can? ..ctx.. ::auth/delete {:type   "Entity"
                                            :owner nil}) => true
         (provided
-          (auth/get-permissions ..auth.. nil) => {}))
+          (auth/permissions ..auth.. nil) => {}))
 
       (fact "allowed when :write on all roots when not owner"
-        (auth/can? ..auth.. ::auth/delete {:type  "Entity"
+        (auth/can? ..ctx.. ::auth/delete {:type   "Entity"
                                            :owner (str (UUID/randomUUID))
                                            :links {:_collaboration_roots ..roots..}}) => true
         (provided
           (auth/authenticated-user-id ..auth..) => (str (UUID/randomUUID))
-          (auth/get-permissions ..auth.. ..roots..) => [{:uuid        :uuid1
+          (auth/permissions ..auth.. ..roots..) => [{:uuid            :uuid1
                                                          :permissions {:read  true
                                                                        :write true
                                                                        :admin true}}
@@ -249,12 +254,12 @@
                                                                        :admin false}}]))
 
       (fact "Requires :write on all roots when not owner"
-        (auth/can? ..auth.. ::auth/delete {:type  "Entity"
+        (auth/can? ..ctx.. ::auth/delete {:type   "Entity"
                                            :owner (str (UUID/randomUUID))
                                            :links {:_collaboration_roots ..roots..}}) => false
         (provided
           (auth/authenticated-user-id ..auth..) => (str (UUID/randomUUID))
-          (auth/get-permissions ..auth.. ..roots..) => {:permissions [{:uuid        :uuid1
+          (auth/permissions ..auth.. ..roots..) => {:permissions [{:uuid            :uuid1
                                                                        :permissions {:read  true
                                                                                      :write false
                                                                                      :admin false}}
@@ -274,7 +279,7 @@
           auth   {:server server}]
       (with-fake-http [{:url (util/join-path [server "api" "v2" "permissions"]) :method :get} {:body   (json/write-str body)
                                                                                                :status 200}]
-        @(auth/permissions auth) => (:permissions body)))))
+        @(auth/get-permissions auth) => (:permissions body)))))
 
 (facts "About `get-permissions`"
   (fact "gets permissions from future stored in authenticated identity"
@@ -285,7 +290,7 @@
                                :permissions ..other-permissions..}]
           future-permissions (promise)]
       (deliver future-permissions permissions)
-      (auth/get-permissions ..auth.. [(first uuids)]) => [{:uuid        (first uuids)
+      (auth/permissions ..auth.. [(first uuids)]) => [{:uuid            (first uuids)
                                                            :permissions ..permisions..}]
       (provided
         ..auth.. =contains=> {::auth/authenticated-permissions future-permissions}))))

--- a/test/ovation/test/core.clj
+++ b/test/ovation/test/core.clj
@@ -30,7 +30,7 @@
           (fact "bulk-updates values"
             (core/create-values ..ctx.. ..db.. [{:type "Annotation"}]) => ..result..
             (provided
-              (auth/check! ..auth.. ::auth/create) => identity
+              (auth/check! ..ctx.. ::auth/create) => identity
               (couch/bulk-docs ..db.. [{:type "Annotation"}]) => ..docs..
               (tr/values-from-couch ..docs.. ..ctx..) => ..result..))))
       (facts "`delete-values`"
@@ -43,7 +43,7 @@
             (core/delete-values ..ctx.. ..db.. [..id..]) => ..result..
             (provided
               (couch/all-docs ..ctx.. ..db.. [..id..]) => [{:type "Annotation"}]
-              (auth/check! ..auth.. ::auth/delete) => identity
+              (auth/check! ..ctx.. ::auth/delete) => identity
               (couch/delete-docs ..db.. [{:type "Annotation"}]) => ..docs..
               (tr/values-from-couch ..docs.. ..ctx..) => ..result..))))
       (facts "update-values"
@@ -53,7 +53,7 @@
           (fact "bulk-updates values"
             (core/update-values ..ctx.. ..db.. [{:type "Annotation"}]) => ..result..
             (provided
-              (auth/check! ..auth.. ::auth/update) => identity
+              (auth/check! ..ctx.. ::auth/update) => identity
               (couch/bulk-docs ..db.. [{:type "Annotation"}]) => ..docs..
               (tr/values-from-couch ..docs.. ..ctx..) => ..result..))))))
 
@@ -184,13 +184,13 @@
           (fact "it updates attributes"
             (core/update-entities ..ctx.. ..db.. [update]) => [updated-entity]
             (provided
-              (auth/can? ..auth.. ::auth/update anything) => true))
+              (auth/can? ..ctx.. ::auth/update anything) => true))
           (fact "it updates allowed keys"
             (let [update-with-revs         (assoc update :revisions ..revs..)
                   updated-entity-with-revs (assoc updated-entity :revisions ..revs..)]
               (core/update-entities ..ctx.. ..db.. [update-with-revs] :allow-keys [:revisions]) => [updated-entity-with-revs]
               (provided
-                (auth/can? ..auth.. ::auth/update anything) => true
+                (auth/can? ..ctx.. ::auth/update anything) => true
                 (couch/bulk-docs ..db.. [update-with-revs]) => [updated-entity-with-revs]
                 (tw/to-couch ..ctx.. [update-with-revs]) => [update-with-revs]
                 (tr/entities-from-couch [updated-entity-with-revs] ..ctx..) => [updated-entity-with-revs])))
@@ -200,7 +200,7 @@
                   updated-entity2 (assoc-in updated-entity [:links :_collaboration_roots] [..roots..])]
               (core/update-entities ..ctx.. ..db.. [update2] :update-collaboration-roots true) => [updated-entity2]
               (provided
-                (auth/can? ..auth.. ::auth/update anything) => true
+                (auth/can? ..ctx.. ::auth/update anything) => true
                 (tw/to-couch ..ctx.. [update2]) => [update2]
                 (couch/bulk-docs ..db.. [update2]) => [updated-entity2]
                 (tr/entities-from-couch [updated-entity2] ..ctx..) => [updated-entity2])))
@@ -208,7 +208,7 @@
           (fact "it fails if authenticated user doesn't have write permission"
             (core/update-entities ..ctx.. ..db.. [update]) => (throws Exception)
             (provided
-              (auth/can? ..auth.. ::auth/update anything) => false))
+              (auth/can? ..ctx.. ::auth/update anything) => false))
 
           (fact "it throws unauthorized if entity is a User"
             (core/update-entities ..ctx.. ..db.. [entity]) => (throws Exception)
@@ -235,7 +235,7 @@
           (tw/to-couch ..ctx.. [restored]) => ..couch-docs..
           (couch/bulk-docs ..db.. ..couch-docs..) => ..restored..
           (tr/entities-from-couch ..restored.. ..ctx..) => ..result..
-          (auth/can? ..auth.. ::auth/update restored) => true)))
+          (auth/can? ..ctx.. ::auth/update restored) => true)))
 
     (facts "delete-entity"
       (let [type       "some-type"
@@ -258,7 +258,7 @@
             (fact "it trashes entity"
               (core/delete-entities ..ctx.. ..db.. [id]) => ..result..
               (provided
-                (auth/can? ..auth.. ::auth/delete anything) => true))
+                (auth/can? ..ctx.. ::auth/delete anything) => true))
 
             (fact "it fails if entity already trashed"
               (core/delete-entities ..ctx.. ..db.. [id]) => (throws Exception)
@@ -268,7 +268,7 @@
             (fact "it fails if authenticated user doesn't have write permission"
               (core/delete-entities ..ctx.. ..db.. [id]) => (throws Exception)
               (provided
-                (auth/can? ..auth.. ::auth/delete anything) => false)))
+                (auth/can? ..ctx.. ::auth/delete anything) => false)))
 
           (fact "it throws unauthorized if entity is a User"
             (core/delete-entities ..ctx.. ..db.. [id]) => (throws Exception)

--- a/test/ovation/test/handler.clj
+++ b/test/ovation/test/handler.clj
@@ -114,7 +114,7 @@
         type-path (typepath type-name)]
     `(let [apikey# TOKEN]
        (against-background [(teams/get-teams anything) => TEAMS
-                            (auth/permissions anything) => PERMISSIONS
+                            (auth/get-permissions anything) => PERMISSIONS
                             (request-context/make-context anything ~org) => ..ctx..
                             ..ctx.. =contains=> {::request-context/routes ..rt..}]
          (facts ~(util/join-path ["" type-path])
@@ -140,7 +140,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
-                            (auth/permissions anything) => PERMISSIONS]
+                            (auth/get-permissions anything) => PERMISSIONS]
          (facts ~(util/join-path ["" type-path])
            (facts "resource"
              (let [id#     (str (UUID/randomUUID))
@@ -175,7 +175,7 @@
         type-path (typepath type-name)]
     `(let [apikey# TOKEN]
        (against-background [(teams/get-teams anything) => TEAMS
-                            (auth/permissions anything) => PERMISSIONS
+                            (auth/get-permissions anything) => PERMISSIONS
                             (teams/create-team anything anything) => {:team ..team..}
                             (auth/identity anything) => ..auth..
                             (request-context/make-context anything ~org) => ..ctx..
@@ -230,7 +230,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
-                            (auth/permissions anything) => PERMISSIONS
+                            (auth/get-permissions anything) => PERMISSIONS
                             (teams/create-team anything anything) => {:team ..team..}
                             (auth/identity anything) => ..auth..
                             (request-context/make-context anything ~org) => ..ctx..
@@ -278,7 +278,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
-                            (auth/permissions anything) => PERMISSIONS
+                            (auth/get-permissions anything) => PERMISSIONS
                             (auth/identity anything) => ..auth..
                             (request-context/make-context anything ~org) => ..ctx..
                             ..ctx.. =contains=> {::request-context/routes ..rt..}]
@@ -336,7 +336,7 @@
     `(let [apikey# TOKEN]
 
        (against-background [(teams/get-teams anything) => TEAMS
-                            (auth/permissions anything) => PERMISSIONS
+                            (auth/get-permissions anything) => PERMISSIONS
                             (auth/identity anything) => ..auth..
                             (request-context/make-context anything ~org) => ..ctx..
                             ..ctx.. =contains=> {::request-context/routes ..rt..}]
@@ -420,7 +420,7 @@
     (facts "About annotations"
       (let [apikey TOKEN]
         (against-background [(teams/get-teams anything) => TEAMS
-                             (auth/permissions anything) => PERMISSIONS
+                             (auth/get-permissions anything) => PERMISSIONS
                              (auth/identity anything) => ..auth..
                              (request-context/make-context anything org) => ..ctx..
                              ..ctx.. =contains=> {::request-context/routes ..rt..}]
@@ -487,7 +487,7 @@
                                 :annotation_type "tags"
                                 :annotation      {:tag "--tag--"}}]]
             (against-background [(teams/get-teams anything) => TEAMS
-                                 (auth/permissions anything) => PERMISSIONS
+                                 (auth/get-permissions anything) => PERMISSIONS
                                  (request-context/make-context anything org) => ..ctx..
                                  (annotations/delete-annotations ..ctx.. db [annotation-id]) => tags]
               (fact "deletes annotations"
@@ -499,7 +499,7 @@
       (facts "About /entities"
         (let [apikey TOKEN]
           (against-background [(teams/get-teams anything) => TEAMS
-                               (auth/permissions anything) => PERMISSIONS
+                               (auth/get-permissions anything) => PERMISSIONS
                                (request-context/make-context anything org) => ..ctx..]
 
             (facts "read"
@@ -555,7 +555,7 @@
       (facts "related Sources"
         (let [apikey TOKEN]
           (against-background [(teams/get-teams anything) => TEAMS
-                               (auth/permissions anything) => PERMISSIONS
+                               (auth/get-permissions anything) => PERMISSIONS
                                (request-context/make-context anything org) => ..ctx..]
             (future-fact "associates created Source")))))
 
@@ -591,7 +591,7 @@
             (body-json app get) => {:revisions revs}
             (provided
               (teams/get-teams anything) => TEAMS
-              (auth/permissions anything) => PERMISSIONS
+              (auth/get-permissions anything) => PERMISSIONS
               (request-context/make-context anything org) => ..ctx..
               ..ctx.. =contains=> {::request-context/routes ..rt..}
               (revisions/get-head-revisions ..ctx.. db id) => revs)))))
@@ -679,7 +679,7 @@
                                 :membership_roles []}
             (provided
               (teams/get-teams anything) => TEAMS
-              (auth/permissions anything) => PERMISSIONS
+              (auth/get-permissions anything) => PERMISSIONS
               (teams/get-team* anything id) => {:team             team
                                                 :users            []
                                                 :membership_roles []})))))
@@ -701,7 +701,7 @@
           (body-json app get) => {:provenance expected}
           (provided
             (teams/get-teams anything) => TEAMS
-            (auth/permissions anything) => PERMISSIONS
+            (auth/get-permissions anything) => PERMISSIONS
             (request-context/make-context anything org) => ..ctx..
             ..ctx.. =contains=> {::request-context/routes ..rt..}
             (prov/local ..ctx.. db [id]) => expected))))

--- a/test/ovation/test/links.clj
+++ b/test/ovation/test/links.clj
@@ -177,12 +177,12 @@
               (links/delete-links ..ctx.. ..db.. doc ..rel.. ..target..) => ..deleted..
               (provided
                 (core/delete-values ..ctx.. ..db.. [link-id]) => ..deleted..
-                (auth/can? ..auth.. ::auth/update doc) => true)))
+                (auth/can? ..ctx.. ::auth/update doc) => true)))
 
           (fact "fails if not can? :update source"
             (links/delete-links ..ctx.. ..db.. ..doc.. ..rel.. ..target..) => (throws Exception)
             (provided
-              (auth/can? ..auth.. ::auth/update ..doc..) => false))
+              (auth/can? ..ctx.. ::auth/update ..doc..) => false))
 
 
           (fact "updates entity _collaboration_roots"
@@ -191,7 +191,7 @@
               (links/delete-links ..ctx.. ..db.. doc ..rel.. ..target..) => ..deleted..
               (provided
                 (core/delete-values ..ctx.. ..db.. [link-id]) => ..deleted..
-                (auth/can? ..auth.. ::auth/update doc) => true))))))
+                (auth/can? ..ctx.. ::auth/update doc) => true))))))
 
     (facts "`get-links`"
       (against-background [(couch/get-view ..ctx.. ..db.. k/LINK-DOCS-VIEW {:startkey      [..id.. ..rel..]

--- a/test/ovation/test/transform.clj
+++ b/test/ovation/test/transform.clj
@@ -199,7 +199,8 @@
         (tr/remove-user-attributes doc) => doc)))
 
   (facts "About permissions"
-    (against-background [..ctx.. =contains=> {::request-context/auth ..auth..}])
+    (against-background [..ctx.. =contains=> {::request-context/auth ..auth..
+                                              ::request-context/org  ..org..}])
     (facts "for entities"
       (let [doc {:owner ..id..}]
         (fact "add-entity-permissions sets {update: (can? :update) delete: (can? :delete)}"
@@ -216,7 +217,8 @@
           (tr/add-value-permissions doc ..ctx..) => (assoc doc :permissions {:update  true
                                                                               :delete true})
           (provided
-            (auth/authenticated-user-id ..auth..) => ..id..)))))
+            (auth/authenticated-user-id ..auth..) => ..id..
+            (auth/organization-ids ..auth..) => [..org..])))))
 
   (facts "About entities-from-couch"
     (fact "removes unauthorized documents"

--- a/test/ovation/test/transform.clj
+++ b/test/ovation/test/transform.clj
@@ -33,7 +33,7 @@
                                    :annotation_type k/TAGS
                                    :entity          ..id..
                                    :_id             ..annotation..
-                                   :links           {:self ..self..}} ..auth..) => {:type            k/ANNOTATION-TYPE
+                                   :links           {:self ..self..}} ..ctx..) => {:type             k/ANNOTATION-TYPE
                                                                                     :annotation_type k/TAGS
                                                                                     :entity          ..id..
                                                                                     :_id             ..annotation..
@@ -199,6 +199,7 @@
         (tr/remove-user-attributes doc) => doc)))
 
   (facts "About permissions"
+    (against-background [..ctx.. =contains=> {::request-context/auth ..auth..}])
     (facts "for entities"
       (let [doc {:owner ..id..}]
         (fact "add-entity-permissions sets {update: (can? :update) delete: (can? :delete)}"
@@ -212,7 +213,7 @@
       (let [doc {:user ..id..
                  :type "Annotation"}]
         (fact "add-value-permissions sets {update: (can? :update) delete: (can? :delete"
-          (tr/add-value-permissions doc ..auth..) => (assoc doc :permissions {:update true
+          (tr/add-value-permissions doc ..ctx..) => (assoc doc :permissions {:update  true
                                                                               :delete true})
           (provided
             (auth/authenticated-user-id ..auth..) => ..id..)))))
@@ -223,5 +224,5 @@
       (provided
         (tr/couch-to-entity ..ctx..) => (fn [doc] doc)
         (auth/authenticated-teams ..auth..) => ..teams..
-        (auth/can? ..auth.. ::auth/read ..doc.. :teams ..teams..) => true
-        (auth/can? ..auth.. ::auth/read ..bad.. :teams ..teams..) => false))))
+        (auth/can? ..ctx.. ::auth/read ..doc.. :teams ..teams..) => true
+        (auth/can? ..ctx.. ::auth/read ..bad.. :teams ..teams..) => false))))


### PR DESCRIPTION
Checks organization memberships (via Rails `team_uuids` at authentication (`auth/can?`). Throws 404 if context organization in the URL is not one of the orgs that the authenticated user is a member of.

Depends on physion/ovation.io#1451