### PR TITLE
Update entities_by_type view for Sources [Delivers #145870389]

### DIFF
--- a/js/api/views/entities_by_type/map.js
+++ b/js/api/views/entities_by_type/map.js
@@ -5,7 +5,7 @@ function(doc) {
 
     if (doc.type) {
         if(doc.owner) {
-            emit([doc.owner, doc.type], null);
+            emit([org, doc.owner, doc.type], null);
             if(doc.type === "Project") {
                 emit([org, doc._id, doc.type], null);
             }

--- a/src/ovation/core.clj
+++ b/src/ovation/core.clj
@@ -18,7 +18,7 @@
   (filter #(or include_trashed (nil? (:trash_info %))) entities))
 
 
-(defn-traced of-type
+(defn of-type
   "Gets all entities of the given type"
   [ctx db resource & {:keys [include-trashed] :or {include-trashed false}}]
 


### PR DESCRIPTION
Make sure that Sources with empty _collboration_roots (e.g. new
sources) are indexed as `[org, owner, “Source”]`