### PR TITLE
Pubsub [Delivers #145319005]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ node_modules
 lein
 
 dev.env
+
+ovation-staging-3a8a26d90eb4.json
+
+ovation-staging.json

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,3 +15,9 @@
     db:
       environment:
         - MYSQL_RANDOM_ROOT_PASSWORD="1"
+    pubsub:
+      image: samnco/pubsub-emulator:2016.01.22
+      ports:
+        - "8042:8042"
+      volumes:
+        - ./logs:/var/log

--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,10 @@
                  [environ "1.1.0"]
 
                  ;; Graph
-                 [ubergraph "0.2.2"]]
+                 [ubergraph "0.2.2"]
+
+                 ;; GCP
+                 [com.google.cloud/google-cloud "0.17.2-alpha"]]
 
 
   :ring {:handler ovation.handler/app

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
                  [ubergraph "0.2.2"]
 
                  ;; GCP
-                 [com.google.cloud/google-cloud "0.17.2-alpha"]]
+                 [com.google.cloud/google-cloud "0.18.0-alpha"]]
 
 
   :ring {:handler ovation.handler/app

--- a/src/ovation/couch.clj
+++ b/src/ovation/couch.clj
@@ -120,7 +120,7 @@
                    {:id   (:_id doc)
                     :rev  (:_rev doc)
                     :type (:type doc)})
-        topic    (config/config :db-updates-topic :default :db-updates)
+        topic    (config/config :db-updates-topic :default :updates)
         channels (map #(pubsub/publish publisher topic (msg-fn %) (chan)) docs)]
 
     (async/pipe (async/merge channels) channel close?)))

--- a/src/ovation/couch.clj
+++ b/src/ovation/couch.clj
@@ -18,8 +18,6 @@
 
 (def design-doc "api")
 
-(def ncpu (.availableProcessors (Runtime/getRuntime)))
-
 (defn db
   "Database URL from authorization info"
   [auth]
@@ -98,11 +96,16 @@
 
       docs)))
 
+(defn publish-updates
+  [publisher bulk-results])
+
 (defn-traced bulk-docs
   "Creates or updates documents"
   [db docs]
   (cl/with-db db
-    (merge-updates docs (cl/bulk-update docs))))
+    (let [bulk-results (cl/bulk-update docs)]
+      ;; TODO publish updates
+      (merge-updates docs bulk-results))))
 
 (defn changes
   "Writes changes to channel c.

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -46,7 +46,7 @@
 (defroutes static-resources
   (route/resources "/public"))
 
-(defn create-app [database authz pubsub]
+(defn create-app [database authz]
   (let [db database]
     (api
       {:swagger {:ui   "/"

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -47,8 +47,7 @@
   (route/resources "/public"))
 
 (defn create-app [database authz pubsub]
-  (let [db              (:connection database)
-        pub (:topics pubsub)]
+  (let [db database]
     (api
       {:swagger {:ui   "/"
                  :spec "/swagger.json"

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -46,8 +46,9 @@
 (defroutes static-resources
   (route/resources "/public"))
 
-(defn create-app [database authz]
-  (let [db (:connection database)]
+(defn create-app [database authz pubsub]
+  (let [db              (:connection database)
+        pub (:topics pubsub)]
     (api
       {:swagger {:ui   "/"
                  :spec "/swagger.json"

--- a/src/ovation/http.clj
+++ b/src/ovation/http.clj
@@ -51,7 +51,7 @@
   [ctx key make-tf]
   (fn
     [response]
-    (if (util/response-exception? response)
+    (if (util/exception? response)
       response
       (let [entities (key response)]
         (map (make-tf ctx) entities)))))
@@ -60,7 +60,7 @@
   [ctx key make-tf]
   (let [tf (make-tf ctx)]
     (fn [response]
-      (if (util/response-exception? response)
+      (if (util/exception? response)
         response
         (let [obj    (key response)
               result (tf obj)]

--- a/src/ovation/main.clj
+++ b/src/ovation/main.clj
@@ -6,9 +6,10 @@
             [ovation.util :as util]))
 
 (defn -main []
-  (component/start (system/create-system {:web   {:port config/PORT}
-                                          :authz {:v1-url (util/join-path [config/SERVICES_API "api" "v1"])
-                                                  :v2-url (util/join-path [config/SERVICES_API "api" "v2"])}
-                                          :db    {:host     (config/config :cloudant-db-url)
-                                                  :username (config/config :cloudant-username)
-                                                  :password (config/config :cloudant-password)}})))
+  (component/start (system/create-system {:web    {:port config/PORT}
+                                          :pubsub {:project-id (config/config :google-cloud-project-id)}
+                                          :authz  {:v1-url (util/join-path [config/SERVICES_API "api" "v1"])
+                                                   :v2-url (util/join-path [config/SERVICES_API "api" "v2"])}
+                                          :db     {:host     (config/config :cloudant-db-url)
+                                                   :username (config/config :cloudant-username)
+                                                   :password (config/config :cloudant-password)}})))

--- a/src/ovation/pubsub.clj
+++ b/src/ovation/pubsub.clj
@@ -11,7 +11,7 @@
 
 (defn make-publisher
   [project-id topic-name]
-  (let [tn (TopicName/create project-id topic-name)]
+  (let [tn (TopicName/create project-id (name topic-name))]
     (-> (Publisher/defaultBuilder tn)
       (.build))))
 
@@ -55,18 +55,18 @@
 
 (defprotocol Topics
   "Publish messages via PubSub"
-  (publish [this topic msg result-ch])
+  (publish [this topic msg ch])
   (shutdown [this]))
 
 (defrecord TopicPublisher [topics]
   Topics
-  (publish [this topic msg result-ch]
+  (publish [this topic msg ch]
     (when-not (get this [:topics topic])
       (let [publisher (make-publisher (:project-id this) topic)]
         (update-in this [:topics] assoc topic publisher)))
 
     (if-let [publisher (get-in this [:topics topic])]
-      (publish-message publisher msg result-ch)))
+      (publish-message publisher msg :channel ch)))
 
   (shutdown [this]
     (if-let [publishers (:topics this)]

--- a/src/ovation/pubsub.clj
+++ b/src/ovation/pubsub.clj
@@ -79,6 +79,5 @@
       (shutdown publisher))
     (assoc this :publisher nil)))
 
-(defn new-pubsub [project-id topic]
-  (map->PubSub {:project-id project-id
-                :topic      topic}))
+(defn new-pubsub [project-id]
+  (map->PubSub {:project-id project-id}))

--- a/src/ovation/pubsub.clj
+++ b/src/ovation/pubsub.clj
@@ -1,1 +1,68 @@
-(ns ovation.pubsub)
+(ns ovation.pubsub
+  (:require [com.stuartsierra.component :as component]
+            [clojure.tools.logging :as logging]
+            [clojure.core.async :refer [go >! >!! chan]])
+  (:import (com.google.pubsub.v1 TopicName PubsubMessage)
+           (com.google.cloud.pubsub.spi.v1 Publisher)
+           (com.google.protobuf ByteString)
+           (com.google.api.core ApiFutures ApiFutureCallback)))
+
+
+(defn make-publisher
+  [project-id topic-name]
+  (let [tn (TopicName/create project-id topic-name)]
+    (doto (Publisher/defaultBuilder tn)
+      (.build))))
+
+(defn make-api-future-callback
+  [ch]
+  (reify ApiFutureCallback
+    (onSuccess [_ result]
+      (>!! ch result))
+    (onFailure [_ throwable]
+      (>!! ch throwable))))
+
+(defn make-msg
+  [message]
+  (let [data (ByteString/copyFromUtf8 message)]
+    (-> (PubsubMessage/newBuilder) (.setData data) (.build))))
+
+(defn publish-message
+  [publisher message & {:keys [msg-ch] :or {msg-ch (chan)}}]
+  (go
+    (let [msg           (make-msg message)
+          msg-id-future (.publish publisher msg)]
+
+      (ApiFutures/addCallback msg-id-future (make-api-future-callback msg-ch))
+      msg-ch)))
+
+(defprotocol TopicPublisher
+  "Publish messages via PubSub"
+  (publish [this topic msg result-ch]))
+
+(defrecord PubSub [project-id]
+  component/Lifecycle
+
+  (start [this]
+    (logging/info "Starting PubSub")
+    (assoc this :publishers {}))
+
+  (stop [this]
+    (logging/info "Stopping PubSub")
+    (if-let [publishers (:publishers this)]
+      ;; Shut down all publishers
+      (map #(.shutdown %) (vals publishers)))
+    (assoc this :publishers nil))
+
+  TopicPublisher
+  (publish [this topic msg result-ch]
+    (when-not (get-in this [:publishers topic])
+      (let [publisher (make-publisher (:project-id this) topic)]
+        (update-in this [:publishers] assoc topic publisher)))
+
+    (if-let [publisher (get-in this [:publishers topic])]
+      (publish-message publisher msg result-ch))))
+
+(defn new-pubsub [project-id topic]
+  (map->PubSub {:project-id project-id
+                :topic      topic}))

--- a/src/ovation/pubsub.clj
+++ b/src/ovation/pubsub.clj
@@ -1,0 +1,1 @@
+(ns ovation.pubsub)

--- a/src/ovation/system.clj
+++ b/src/ovation/system.clj
@@ -2,9 +2,9 @@
   (:require [com.stuartsierra.component :as component]
             [clojure.tools.logging :as logging]
             [ovation.handler :as handler]
+            [ovation.pubsub :as pubsub]
             (system.components
-              [http-kit :as system-http-kit]
-              [jetty :as system-jetty])
+              [http-kit :as system-http-kit])
             [cemerick.url :as url]
             [ovation.authz :as authz]))
 
@@ -56,14 +56,16 @@
 
 ;; System
 (defn create-system [config-options]
-  (let [{:keys [web db authz]} config-options]
+  (let [{:keys [web db authz pubsub]} config-options]
     (component/system-map
       :database (new-database (:host db) (:username db) (:password db))
       :web (component/using
              (system-http-kit/new-web-server (:port web))
              {:handler :api})
       :authz (authz/new-authz-service (:v1-url authz) (:v2-url authz))
+      :pubsub (pubsub/new-pubsub (:project-id pubsub) (:topic pubsub))
       :api (component/using
              (new-api)
-             {:db    :database
-              :authz :authz}))))
+             {:db     :database
+              :authz  :authz
+              :pubsub :pubsub}))))

--- a/src/ovation/system.clj
+++ b/src/ovation/system.clj
@@ -63,7 +63,7 @@
              (system-http-kit/new-web-server (:port web))
              {:handler :api})
       :authz (authz/new-authz-service (:v1-url authz) (:v2-url authz))
-      :pubsub (pubsub/new-pubsub (:project-id pubsub) (:topic pubsub))
+      :pubsub (pubsub/new-pubsub (:project-id pubsub))
       :api (component/using
              (new-api)
              {:db     :database

--- a/src/ovation/system.clj
+++ b/src/ovation/system.clj
@@ -27,12 +27,12 @@
 
 
 ;; API
-(defrecord Api [db authz]
+(defrecord Api [db authz pubsub]
   component/Lifecycle
 
   (start [this]
     (logging/info "Starting API")
-    (assoc this :handler (handler/create-app db authz)))
+    (assoc this :handler (handler/create-app db authz pubsub)))
 
   (stop [this]
     (logging/info "Stopping API")

--- a/src/ovation/util.clj
+++ b/src/ovation/util.clj
@@ -113,7 +113,7 @@
 (defn ncpus []
   (.availableProcessors (Runtime/getRuntime)))
 
-(defn response-exception?
+(defn exception?
   "Tests response for Throwable or :ring.util.http-response/response"
   [response]
   (or
@@ -126,7 +126,7 @@
    This function comes from David Nolen"
   [c]
   (let [returned (<!! c)]
-    (if (response-exception? returned)
+    (if (exception? returned)
       (throw+ returned)
       returned)))
 

--- a/test/ovation/test/couch.clj
+++ b/test/ovation/test/couch.clj
@@ -2,31 +2,18 @@
   (:use midje.sweet)
   (:require [cemerick.url :as url]
             [ovation.couch :as couch]
-            [clojure.core.async :refer [chan <!!]]
+            [clojure.core.async :refer [chan <!!] :as async]
             [com.ashafa.clutch :as cl]
-            [ovation.auth :as auth]
+            [ovation.util :refer [<??]]
             [ovation.constants :as k]
             [ovation.config :as config]
             [ovation.request-context :as rc]
             [ovation.pubsub :as pubsub]))
 
-(facts "About `db`"
-  (fact "it constructs database URL"
-    (let [dburl "https://db.db"
-          username "db-user"
-          password "db-pass"]
-
-      (couch/db ..auth..) => (-> (url/url dburl)
-                                 (assoc :username username
-                                        :password password))
-      (provided
-        (config/config :cloudant-db-url) => dburl
-        (config/config :cloudant-username) => username
-        (config/config :cloudant-password) => password))))
-
 
 (against-background [(rc/team-ids ..ctx..) => [..team..]
-                     (rc/user-id ..ctx..) => ..user..]
+                     (rc/user-id ..ctx..) => ..user..
+                     ..db.. =contains=> {:connection ..db..}]
 
   (facts "About `get-view`"
     (fact "it returns CouchDB view result docs when include_docs=true"
@@ -76,15 +63,20 @@
       (provided
         (cl/bulk-update ..docs..) => ..revs..
         (couch/merge-updates ..docs.. ..revs..) => ..result..))
-    (fact "publishes updates"
-      (couch/bulk-docs "dburl" ..docs..) => ..result..
+    (fact "it publishes updates"
+      (couch/bulk-docs ..db.. ..docs..) => ..result..
       (provided
+        ..db.. =contains=> {:connection "db-url"
+                            :publisher  ..pub..}
         (cl/bulk-update ..docs..) => ..revs..
         (couch/publish-updates ..pub.. ..revs..) => ..published..
         (couch/merge-updates ..docs.. ..revs..) => ..result..)))
 
   (facts "About publish-updates"
-    (future-fact "publishes to :all-updates"))
+    (fact "publishes to :all-updates"
+      (first (async/alts!! [(couch/publish-updates ..pub.. [..doc..]) (async/timeout 100)])) => [..doc..]
+      (provided
+        )))
 
   (facts "About `delete-docs`"
     (fact "it POSTs bulk-update"

--- a/test/ovation/test/couch.clj
+++ b/test/ovation/test/couch.clj
@@ -7,7 +7,8 @@
             [ovation.auth :as auth]
             [ovation.constants :as k]
             [ovation.config :as config]
-            [ovation.request-context :as rc]))
+            [ovation.request-context :as rc]
+            [ovation.pubsub :as pubsub]))
 
 (facts "About `db`"
   (fact "it constructs database URL"
@@ -88,7 +89,16 @@
       (couch/bulk-docs "dburl" ..docs..) => ..result..
       (provided
         (cl/bulk-update ..docs..) => ..revs..
+        (couch/merge-updates ..docs.. ..revs..) => ..result..))
+    (fact "publishes updates"
+      (couch/bulk-docs "dburl" ..docs..) => ..result..
+      (provided
+        (cl/bulk-update ..docs..) => ..revs..
+        (couch/publish-updates ..pub.. ..revs..) => ..published..
         (couch/merge-updates ..docs.. ..revs..) => ..result..)))
+
+  (facts "About publish-updates"
+    (future-fact "publishes to :all-updates"))
 
   (facts "About `delete-docs`"
     (fact "it POSTs bulk-update"

--- a/test/ovation/test/couch.clj
+++ b/test/ovation/test/couch.clj
@@ -79,9 +79,9 @@
         (async/alts!! [(couch/publish-updates ..pub.. [..doc..] :channel ch)
                        (async/timeout 100)]) => [..result.. ch]
         (provided
-          (pubsub/publish ..pub.. :db-updates {:id   ..id..
-                                               :rev  ..rev..
-                                               :type ..type..} anything) => pchan
+          (pubsub/publish ..pub.. :updates {:id   ..id..
+                                            :rev  ..rev..
+                                            :type ..type..} anything) => pchan
           ..doc.. =contains=> {:_id  ..id..
                                :_rev ..rev..
                                :type ..type..}))))

--- a/test/ovation/test/couch.clj
+++ b/test/ovation/test/couch.clj
@@ -66,7 +66,7 @@
       (couch/bulk-docs ..db.. ..docs..) => ..result..
       (provided
         ..db.. =contains=> {:connection "db-url"
-                            :publisher  ..pub..}
+                            :pubsub     {:publisher ..pub..}}
         (cl/bulk-update ..docs..) => ..revs..
         (couch/publish-updates ..pub.. ..revs.. :channel anything) => ..published..
         (couch/merge-updates ..docs.. ..revs..) => ..result..)))
@@ -79,9 +79,9 @@
         (async/alts!! [(couch/publish-updates ..pub.. [..doc..] :channel ch)
                        (async/timeout 100)]) => [..result.. ch]
         (provided
-          (pubsub/publish-message ..pub.. {:id   ..id..
-                                           :rev  ..rev..
-                                           :type ..type..}) => pchan
+          (pubsub/publish ..pub.. :db-updates {:id   ..id..
+                                               :rev  ..rev..
+                                               :type ..type..} anything) => pchan
           ..doc.. =contains=> {:_id  ..id..
                                :_rev ..rev..
                                :type ..type..}))))

--- a/test/ovation/test/pubsub.clj
+++ b/test/ovation/test/pubsub.clj
@@ -1,5 +1,23 @@
 (ns ovation.test.pubsub
   (:use midje.sweet)
-  (:require [ovation.pubsub :as pubsub]))
+  (:require [ovation.pubsub :as pubsub]
+            [ovation.util :refer [<??]]
+            [clojure.core.async :as async]))
 
-(facts "About pubsub")
+(facts "About pubsub"
+  (facts "publish-message"
+    (fact "publishes to a topic"
+      (let [message {:foo "bar"}]
+        (let [ch (async/chan)]
+          (pubsub/publish-message ..pub.. message)
+          (.onSuccess (pubsub/future-to-ch ch) message)
+          (first (async/alts!! [(async/timeout 100) ch]))) => message
+        (provided
+          (pubsub/make-msg message) => ..msg..
+          (pubsub/send-msg ..pub.. ..msg..) => ..future..
+          (pubsub/add-api-callback ..future.. anything) => nil))))
+  (facts "future-to-ch"
+    (fact "propagates exceptions"
+      (let [ch (async/chan)]
+        (.onFailure (pubsub/future-to-ch ch) (Exception. "Boom"))
+        (<?? ch)) => (throws Throwable))))

--- a/test/ovation/test/pubsub.clj
+++ b/test/ovation/test/pubsub.clj
@@ -1,0 +1,5 @@
+(ns ovation.test.pubsub
+  (:use midje.sweet)
+  (:require [ovation.pubsub :as pubsub]))
+
+(facts "About pubsub")

--- a/test/ovation/test/system.clj
+++ b/test/ovation/test/system.clj
@@ -42,4 +42,4 @@
   (get-in test-system [:api :handler]))
 
 (defn get-db []
-  (get-in test-system [:database :connection]))
+  (get-in test-system [:database]))

--- a/test/ovation/test/system.clj
+++ b/test/ovation/test/system.clj
@@ -5,12 +5,13 @@
             [ovation.util :as util]))
 
 (def system-config
-  {:web   {:port 3000}
-   :authz {:v1-url (util/join-path [config/SERVICES_API "api" "v1"])
-           :v2-url (util/join-path [config/SERVICES_API "api" "v2"])}
-   :db    {:host     (config/config :cloudant-db-url :default "https://db-host")
-           :username (config/config :cloudant-username :default "db-username")
-           :password (config/config :cloudant-password :default "db-password")}})
+  {:web    {:port 3000}
+   :authz  {:v1-url (util/join-path [config/SERVICES_API "api" "v1"])
+            :v2-url (util/join-path [config/SERVICES_API "api" "v2"])}
+   :pubsub {:project-id (config/config :google-cloud-project-id :default "gcp-project-id")}
+   :db     {:host     (config/config :cloudant-db-url :default "https://db-host")
+            :username (config/config :cloudant-username :default "db-username")
+            :password (config/config :cloudant-password :default "db-password")}})
 
 (def test-system nil)
 


### PR DESCRIPTION
Adds publication of all updates (to `updates` topic) and all revision upload completion (to `revisions` topic) via Google Pub/Sub.

- Google cloud API dependency for pubsub
- PubSub component
- Db component depends on PubSub component
- `TopicsPublisher` API for publishing to existing topics (does not support creation of new topics)
- `couch/bulk-docs` sends `:updates` messages (asynchronous)
- `revisoins/update-metadata` sends `:revisions` messages (asynchronous)