### PR TITLE
Handle no-content responses in call-http [Delivers #146497489]

### DIFF
--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -191,7 +191,8 @@
                       :name :delete-org-membership
                       :return {}
                       :summary "Delete the organization membership for a user"
-                      (ok (authz/delete-organization-membership authz (request-context/make-context request org authz) id)))))
+                      (let [_ (authz/delete-organization-membership authz (request-context/make-context request org authz) id)]
+                        (no-content)))))
 
                 (context "/groups" []
                   :tags ["admin"]
@@ -229,7 +230,8 @@
                       :name :delete-org-group
                       :return {}
                       :summary "Delete a group"
-                      (ok (authz/delete-organization-group authz (request-context/make-context request org authz) id)))
+                      (let [_ (authz/delete-organization-group authz (request-context/make-context request org authz) id)]
+                        (no-content)))
 
                     (context "/memberships" []
                       :tags ["admin"]
@@ -268,7 +270,8 @@
                           :name :delete-group-membership
                           :return {}
                           :summary "Delete a group membereship to remove the associated user from the group"
-                          (ok (authz/delete-organization-group-membership authz (request-context/make-context request org authz) membership-id)))))))
+                          (let [_ (authz/delete-organization-group-membership authz (request-context/make-context request org authz) membership-id)]
+                            (no-content)))))))
 
                 (context "/entities" []
                   :tags ["entities"]

--- a/src/ovation/http.clj
+++ b/src/ovation/http.clj
@@ -23,10 +23,12 @@
         (logging/debug "Raw:" (:body resp)))
       (if (success-fn resp)
         (try+
-          (let [body (util/from-json (:body resp))]
-            (if log-response?
-              (logging/debug "Response:" body))
-            (>!! ch body))
+          (if (hp/no-content? resp)
+            (>!! ch {})
+            (let [body (util/from-json (:body resp))]
+              (if log-response?
+                (logging/debug "Response:" body))
+              (>!! ch body)))
           (catch EOFException _
             (logging/info "Response is empty")
             (let [err {:type :ring.util.http-response/response :response resp}]


### PR DESCRIPTION
When the body is empty *AND* the status is 204, return `{}` rather than
try to parse the (empty) JSON.