### PR TITLE
Codeship pro [Delivers #145692569]

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,0 +1,9 @@
+web:
+  build:
+    image: webapi
+    dockerfile: Dockerfile
+  links:
+    - db
+  env_file: dev.env
+db:
+  image: mysql

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,9 +1,30 @@
 web:
   build:
-    image: webapi
+    image: web
     dockerfile: Dockerfile
   links:
     - db
+    - pubsub
   env_file: dev.env
+  cached: true
+
 db:
   image: mysql
+
+pubsub:
+  image: niallmccullagh/docker-google-cloud-emulators:latest
+  ports:
+    - "8538:8538"
+  command: /bin/bash -c "gcloud config set project emulator && gcloud beta emulators pubsub start --data-dir /mnt/data/pubsub --host-port 0.0.0.0:8538"
+
+google_cloud_deployment:
+  image: codeship/google-cloud-deployment
+  add_docker: true
+  encrypted_env_file: gc.env.encrypted
+  volumes:
+    - ./:/deploy
+
+gcr_dockercfg:
+  image: codeship/gcr-dockercfg-generator
+  add_docker: true
+  encrypted_env_file: gc.env.encrypted

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,0 +1,13 @@
+- type: parallel
+  steps:
+    - name: test
+      service: web
+      command: lein midje
+
+- type: serial
+  steps:
+    - name: gce_push
+      tag: master
+      service: web
+      type: push
+

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -6,8 +6,19 @@
 
 - type: serial
   steps:
-    - name: gce_push
+    - name: gce_push #TODO https://documentation.codeship.com/pro/continuous-deployment/google-cloud/, https://documentation.codeship.com/pro/continuous-deployment/deployment-with-kubernetes/
+      type: push
       tag: master
+      service: web
+      image_name: gcr.io/ovation/ovation-webapi
+      image_tag: "{{ .Timestamp }}"
+      registry: https://gcr.io
+      dockercfg_service: gcr_dockercfg
+    - name: gce_deploy #TODO https://documentation.codeship.com/pro/continuous-deployment/deployment-with-kubernetes/
+      tag: master
+      command: /deploy/gce_deploy.sh
+    - name: heroku_push #TODO https://documentation.codeship.com/pro/continuous-deployment/heroku/
+      tag: development
       service: web
       type: push
 

--- a/jenkins_midje.clj
+++ b/jenkins_midje.clj
@@ -1,3 +1,0 @@
-(change-defaults :emitter 'midje.emission.plugins.junit
-  :print-level :print-facts
-  :colorize false)

--- a/src/ovation/config.clj
+++ b/src/ovation/config.clj
@@ -1,27 +1,21 @@
 (ns ovation.config
-  (:require [environ.core :refer [env]]))
+  (:require [environ.core :refer [env]]
+            [ovation.util :as util]))
 
 (defn config
   [name & {:keys [default] :or {default nil}}]
   (or (env name) default))
 
-(def JWT_SECRET (config :jwt-secret))
-(def NOTIFICATIONS_SERVER (config :notifications-server))
-(def AUTH_SERVER (config :auth-server))
-
-(def RESOURCES_SERVER (config :resources-server))
-
-(def TEAMS_SERVER (config :teams-server))
-
-(def LOGGING_HOST (config :logging-host))
-(def LOGGING_PORT (config :logging-port))
-
-(def CLOUDANT_DB_URL (config :cloudant-db-url))
-(def CLOUDANT_USERNAME (config :clouddant-username))
-(def CLOUDANT_PASSWORD (config :cloudant-password))
-
 (def PORT (Integer/parseInt (str (config :port :default 3000))))
-(def ZIP_SERVICE (config :zip-service :default "https://zip-staging.ovation.io"))
 
+(def JWT_SECRET (config :jwt-secret))
+
+(def SERVICES_API_URL (config :ovation-io-host-uri :default "https://services-staging.ovation.io"))
+
+(def NOTIFICATIONS_SERVER SERVICES_API_URL)
+(def AUTH_SERVER SERVICES_API_URL)
+(def RESOURCES_SERVER SERVICES_API_URL)
+(def TEAMS_SERVER (util/join-path [SERVICES_API_URL "api" "v2"]))
 (def ORGS_SERVER TEAMS_SERVER)
-(def SERVICES_API (config :ovation-io-host-uri :default "https://services-staging.ovation.io"))
+
+(def ZIP_SERVICE (config :zip-service :default "https://zip-staging.ovation.io"))

--- a/src/ovation/main.clj
+++ b/src/ovation/main.clj
@@ -8,7 +8,7 @@
 (defn -main []
   (component/start (system/create-system {:web    {:port config/PORT}
                                           :pubsub {:project-id (config/config :google-cloud-project-id)}
-                                          :authz  {:services-url (util/join-path [config/SERVICES_API "api" "v2"])}
+                                          :authz  {:services-url (util/join-path [config/SERVICES_API_URL "api" "v2"])}
                                           :db     {:host     (config/config :cloudant-db-url)
                                                    :username (config/config :cloudant-username)
                                                    :password (config/config :cloudant-password)}})))

--- a/src/ovation/revisions.clj
+++ b/src/ovation/revisions.clj
@@ -98,9 +98,9 @@
 
     (let [body {:entity_id (:_id revision)
                 :path      (get-in revision [:attributes :name] (:_id revision))}
-          resp (http/post config/RESOURCES_SERVER {:oauth-token (request-context/token ctx)
-                                                   :body        (util/to-json body)
-                                                   :headers     {"Content-Type" "application/json"}})]
+          resp (http/post (util/join-path [config/RESOURCES_SERVER "api" "v1" "resources"]) {:oauth-token (request-context/token ctx)
+                                                   :body                                                  (util/to-json body)
+                                                   :headers                                               {"Content-Type" "application/json"}})]
       (when-not (= (:status @resp) 201)
         (throw+ {:type ::resource-creation-failed :message (util/from-json (:body @resp)) :status (:status @resp)}))
 
@@ -133,7 +133,7 @@
   (if (re-find #"ovation.io" (get-in revision [:attributes :url]))
     ;; /api/v1/resources Resource
     (let [rsrc-id (last (string/split (get-in revision [:attributes :url]) #"/"))
-          resp    (http/get (util/join-path [config/RESOURCES_SERVER rsrc-id "metadata"])
+          resp    (http/get (util/join-path [config/RESOURCES_SERVER "api" "v1" "resources" rsrc-id "metadata"])
                     {:oauth-token (request-context/token ctx)
                      :headers     {"Content-Type" "application/json"
                                    "Accept"       "application/json"}})

--- a/src/ovation/user.clj
+++ b/src/ovation/user.clj
@@ -6,13 +6,13 @@
             [ovation.util :as util]))
 
 (def system-config
-  {:web   {:port 3000}
+  {:web    {:port 3000}
    :pubsub {:project-id (config/config :google-cloud-project-id :default "gcp-project-id")}
-   :authz {:services-url (util/join-path [config/SERVICES_API "api" "v2"])}
-   :db    {:host     (config/config :cloudant-db-url)
-           :port     nil
-           :username (config/config :cloudant-username)
-           :password (config/config :cloudant-password)}})
+   :authz  {:services-url (util/join-path [config/SERVICES_API_URL "api" "v2"])}
+   :db     {:host     (config/config :cloudant-db-url)
+            :port     nil
+            :username (config/config :cloudant-username)
+            :password (config/config :cloudant-password)}})
 
 (def dev-system nil)
 

--- a/test/ovation/test/organizations.clj
+++ b/test/ovation/test/organizations.clj
@@ -16,7 +16,7 @@
         user-id          10
         org-id           3
         group-id         21
-        service-url      (util/join-path [config/SERVICES_API "api" "v2"])
+        service-url      (util/join-path [config/SERVICES_API_URL "api" "v2"])
         rails-membership {"id"              id
                           "user_id"         user-id
                           "organization_id" org-id}]
@@ -124,7 +124,7 @@
   (let [id          1
         user-id     10
         org-id      3
-        service-url (util/join-path [config/SERVICES_API "api" "v2"])
+        service-url (util/join-path [config/SERVICES_API_URL "api" "v2"])
         rails-group {"id"              id
                      "user_id"         user-id
                      "organization_id" org-id}]
@@ -246,7 +246,7 @@
         user-id          10
         user-email       "user@example.com"
         org-id           3
-        service-url      (util/join-path [config/SERVICES_API "api" "v2"])
+        service-url      (util/join-path [config/SERVICES_API_URL "api" "v2"])
         rails-membership {"id"              id
                           "user_id"         user-id
                           "email"           user-email

--- a/test/ovation/test/system.clj
+++ b/test/ovation/test/system.clj
@@ -6,7 +6,7 @@
 
 (def system-config
   {:web    {:port 3000}
-   :authz  {:services-url (util/join-path [config/SERVICES_API "api" "v2"])}
+   :authz  {:services-url (util/join-path [config/SERVICES_API_URL "api" "v2"])}
    :pubsub {:project-id (config/config :google-cloud-project-id :default "gcp-project-id")}
    :db     {:host     (config/config :cloudant-db-url :default "https://db-host")
             :username (config/config :cloudant-username :default "db-username")


### PR DESCRIPTION
Adds Codeship Pro build support via `codeship-services.yml` and `codeship-steps.yml`. Still missing Google Code and Heroku deployment configuration; we have to convert the project to Pro and get encryption keys before we can pull the trigger.