### PR TITLE
Updating default url to point to app-services-staging

### DIFF
--- a/src/ovation/config.clj
+++ b/src/ovation/config.clj
@@ -10,7 +10,7 @@
 
 (def JWT_SECRET (config :jwt-secret))
 
-(def SERVICES_API_URL (config :ovation-io-host-uri :default "https://services-staging.ovation.io"))
+(def SERVICES_API_URL (config :ovation-io-host-uri :default "https://app-services-staging.ovation.io"))
 
 (def NOTIFICATIONS_SERVER SERVICES_API_URL)
 (def AUTH_SERVER SERVICES_API_URL)


### PR DESCRIPTION
Already updated the env vars on Heroku; just updating for consistency sake.