### PR TITLE
Group projects [Delivers #147377257]

### DIFF
--- a/src/ovation/authz.clj
+++ b/src/ovation/authz.clj
@@ -40,7 +40,7 @@
 
   (get-team-groups [this ctx team-id])
   (post-team-group [this ctx body])
-  (get-team-group [thx ctx group-id])
+  (get-team-group [this ctx group-id])
   (put-team-group [this ctx group-id body])
   (delete-team-group [this ctx group-id]))
 

--- a/src/ovation/authz.clj
+++ b/src/ovation/authz.clj
@@ -5,8 +5,7 @@
             [clojure.core.async :as async :refer [chan go <!]]
             [ovation.util :refer [<??]]
             [ovation.http :as http]
-            [ovation.groups :as groups]
-            [ovation.util :as util]))
+            [ovation.groups :as groups]))
 
 
 (defprotocol AuthzApi
@@ -31,6 +30,7 @@
   (get-organization-group [this ctx id])
   (put-organization-group [this ctx id body])
   (delete-organization-group [this ctx id])
+  (get-organization-group-project-ids [this ctx group-id])
 
   (get-organization-groups-memberships [this ctx group-id])
   (create-organization-group-membership [this ctx body])
@@ -42,8 +42,7 @@
   (post-team-group [this ctx body])
   (get-team-group [this ctx group-id])
   (put-team-group [this ctx group-id body])
-  (delete-team-group [this ctx group-id])
-  (get-team-group-project-ids [this ctx group-id]))
+  (delete-team-group [this ctx group-id]))
 
 (defn get-authorizations
   [ctx url-base ch]
@@ -220,6 +219,11 @@
   (delete-team-group [this ctx group-id]
     (let [ch (chan)]
       (groups/delete-team-group ctx (:services-url this) group-id ch)
+      (<?? ch)))
+
+  (get-organization-group-project-ids [this ctx group-id]
+    (let [ch (chan)]
+      (organizations/group-project-ids ctx (:services-url this) group-id ch)
       (<?? ch))))
 
 

--- a/src/ovation/authz.clj
+++ b/src/ovation/authz.clj
@@ -2,11 +2,11 @@
   (:require [ovation.organizations :as organizations]
             [clojure.tools.logging :as logging]
             [com.stuartsierra.component :as component]
-            [clojure.core.async :refer [chan]]
+            [clojure.core.async :as async :refer [chan go <!]]
             [ovation.util :refer [<??]]
             [ovation.http :as http]
-            [clojure.core.async :as async]
-            [ovation.groups :as groups]))
+            [ovation.groups :as groups]
+            [ovation.util :as util]))
 
 
 (defprotocol AuthzApi
@@ -42,7 +42,8 @@
   (post-team-group [this ctx body])
   (get-team-group [this ctx group-id])
   (put-team-group [this ctx group-id body])
-  (delete-team-group [this ctx group-id]))
+  (delete-team-group [this ctx group-id])
+  (get-team-group-project-ids [this ctx group-id]))
 
 (defn get-authorizations
   [ctx url-base ch]

--- a/src/ovation/groups.clj
+++ b/src/ovation/groups.clj
@@ -1,11 +1,11 @@
 (ns ovation.groups
   (:require [ring.util.http-response :refer [throw! bad-request! not-found! unprocessable-entity! unprocessable-entity]]
-            [clojure.core.async :refer [chan >!! >! <! go promise-chan]]
+            [clojure.core.async :refer [chan >!! >! <! go]]
             [slingshot.support :refer [get-throwable]]
             [ovation.http :as http]
             [slingshot.slingshot :refer [try+]]
             [ovation.constants :as k]
-            [ovation.core :as core]))
+            [ovation.util :as util]))
 
 (defn make-read-team-group-tf
   [_]

--- a/src/ovation/groups.clj
+++ b/src/ovation/groups.clj
@@ -48,3 +48,12 @@
   (http/destroy-resource ctx url k/TEAM-GROUPS group-id ch
     :response-key :team_group)
   ch)
+
+(defn get-group-projects
+  [ctx db group-id]
+  (let [ch (chan)]
+    ; authz/get-team-group-async
+    ; <?? uuids
+    ; (core/get-entities)
+    )
+  [])

--- a/src/ovation/groups.clj
+++ b/src/ovation/groups.clj
@@ -4,7 +4,8 @@
             [slingshot.support :refer [get-throwable]]
             [ovation.http :as http]
             [slingshot.slingshot :refer [try+]]
-            [ovation.constants :as k]))
+            [ovation.constants :as k]
+            [ovation.core :as core]))
 
 (defn make-read-team-group-tf
   [_]
@@ -48,12 +49,3 @@
   (http/destroy-resource ctx url k/TEAM-GROUPS group-id ch
     :response-key :team_group)
   ch)
-
-(defn get-group-projects
-  [ctx db group-id]
-  (let [ch (chan)]
-    ; authz/get-team-group-async
-    ; <?? uuids
-    ; (core/get-entities)
-    )
-  [])

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -357,10 +357,10 @@
                   (GET "/" request
                     :name :all-projects
                     :return {:projects [Project]}
-                    :query-params [{group_id :- Id nil}]
+                    :query-params [{organization_group_id :- Id nil}]
                     :summary "Gets all top-level projects"
                     (let [ctx      (request-context/make-context request org authz)
-                          group-id group_id]
+                          group-id organization_group_id]
                       (if (nil? group-id)
                         (let [entities (core/of-type ctx db "Project")]
                           (ok {:projects entities}))

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -20,6 +20,7 @@
             [ovation.search :as search]
             [ovation.breadcrumbs :as breadcrumbs]
             [ovation.request-context :as request-context]
+            [ovation.groups :as groups]
             [schema.core :as s]
             [ovation.teams :as teams]
             [new-reliquary.ring :refer [wrap-newrelic-transaction]]
@@ -352,7 +353,20 @@
 
                 (context "/projects" []
                   :tags ["projects"]
-                  (get-resources db org authz "Project")
+
+                  (GET "/" request
+                    :name :all-projects
+                    :return {:projects [Project]}
+                    :query-params [{group_id :- Id nil}]
+                    :summary "Gets all top-level projects"
+                    (let [ctx      (request-context/make-context request org authz)
+                          group-id group_id]
+                      (if (nil? group-id)
+                        (let [entities (core/of-type ctx db "Project")]
+                          (ok {:projects entities}))
+                        (let [entities (groups/get-group-projects ctx db group-id)]
+                          (ok {:projects entities})))))
+
                   (post-resources db org authz "Project" [NewProject])
                   (context "/:id" []
                     :path-params [id :- s/Str]
@@ -371,7 +385,7 @@
 
                 (context "/sources" []
                   :tags ["sources"]
-                  (get-resources db org authz "Source")
+                  (get-resources db org authz "Source" Source)
                   (post-resources db org authz "Source" [NewSource])
                   (context "/:id" []
                     :path-params [id :- s/Str]
@@ -390,7 +404,7 @@
 
                 (context "/activities" []
                   :tags ["activities"]
-                  (get-resources db org authz "Activity")
+                  (get-resources db org authz "Activity" Activity)
                   (post-resources db org authz "Activity" [NewActivity])
                   (context "/:id" []
                     :path-params [id :- s/Str]
@@ -407,7 +421,7 @@
 
                 (context "/folders" []
                   :tags ["folders"]
-                  (get-resources db org authz "Folder")
+                  (get-resources db org authz "Folder" Folder)
                   (context "/:id" []
                     :path-params [id :- s/Str]
 
@@ -436,7 +450,7 @@
 
                 (context "/files" []
                   :tags ["files"]
-                  (get-resources db org authz "File")
+                  (get-resources db org authz "File" File)
                   (context "/:id" []
                     :path-params [id :- s/Str]
 

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -364,7 +364,8 @@
                       (if (nil? group-id)
                         (let [entities (core/of-type ctx db "Project")]
                           (ok {:projects entities}))
-                        (let [entities (groups/get-group-projects ctx db group-id)]
+                        (let [project-ids (authz/get-organization-group-project-ids authz ctx group-id)
+                              entities (core/get-entities ctx db project-ids)]
                           (ok {:projects entities})))))
 
                   (post-resources db org authz "Project" [NewProject])

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -630,8 +630,8 @@
                           :summary "Deletes a team membership, removing the team member."
                           (let [ctx (request-context/make-context request org authz)]
                             (teams/delete-membership* ctx mid)
-                            (no-content)))))
-                    ))
+                            (no-content)))))))
+
 
                 (context "/roles" []
                   :tags ["teams"]

--- a/src/ovation/organizations.clj
+++ b/src/ovation/organizations.clj
@@ -260,6 +260,8 @@
     (get-group ctx url group-id group-ch)
     (go
       (let [response (<! group-ch)]
+        (println response)
         (if (util/exception? response)
           (>! ch response)
-          (>! ch (get-in response [:organization-group :team_uuids])))))))
+          (>! ch (:team_ids response)))))
+    ch))

--- a/src/ovation/route_helpers.clj
+++ b/src/ovation/route_helpers.clj
@@ -87,19 +87,19 @@
     ;;default
     (lower-case (str typename "s"))))
 
-(defmacro get-resources
+(defn get-resources
   "Get all resources of type (e.g. \"Project\")"
-  [db org authz entity-type]
+  [db org authz entity-type record-schema]
   (let [type-name (capitalize entity-type)
         type-path (typepath type-name)
         type-kw   (keyword type-path)]
-    `(GET "/" request#
-       :name ~(keyword (str "all-" (lower-case type-name)))
-       :return {~type-kw [~(clojure.core/symbol "ovation.schema" type-name)]}
-       :summary (str "Gets all top-level " ~type-path)
-       (let [ctx# (request-context/make-context request# ~org ~authz)
-             entities# (core/of-type ctx# ~db ~type-name)]
-         (ok {~type-kw entities#})))))
+    (GET "/" request
+      :name (keyword (str "all-" (lower-case type-name)))
+      :return {type-kw [record-schema]}
+      :summary (str "Gets all top-level " type-path)
+      (let [ctx      (request-context/make-context request org authz)
+            entities (core/of-type ctx db type-name)]
+        (ok {type-kw entities})))))
 
 (defn remove-embedded-relationships
   [entities]

--- a/test/ovation/test/authz.clj
+++ b/test/ovation/test/authz.clj
@@ -4,7 +4,8 @@
             [ovation.util :as util]
             [ovation.request-context :as request-context]
             [org.httpkit.fake :refer [with-fake-http]]
-            [clojure.core.async :as async]))
+            [clojure.core.async :as async :refer [go >!]]
+            [ovation.groups :as groups]))
 
 
 (facts "About AuthzService"
@@ -16,16 +17,5 @@
         ..ctx.. =contains=> {::request-context/org ..org..}
         (async/promise-chan) => ..ch..
         (authz/get-authorizations ..ctx.. ..url.. ..ch..) => ..go..
-        (util/<?? ..ch..) => ..result..)))
-
-
-  (facts "`get-team-group-project-ids`"
-    (fact "Gets projects by group->projects UUIDs"
-      (let [group-id    1
-            rails-group {:team_ids ..ids..}
-            authz       (authz/new-authz-service ..url..)]
-
-        (authz/get-team-group-project-ids authz ..ctx.. group-id) => ..ids..
-        (provided
-          (authz/get-team-group authz ..ctx.. group-id) => {:team-group rails-group})))))
+        (util/<?? ..ch..) => ..result..))))
 

--- a/test/ovation/test/authz.clj
+++ b/test/ovation/test/authz.clj
@@ -3,6 +3,7 @@
   (:require [ovation.authz :as authz]
             [ovation.util :as util]
             [ovation.request-context :as request-context]
+            [org.httpkit.fake :refer [with-fake-http]]
             [clojure.core.async :as async]))
 
 
@@ -15,4 +16,16 @@
         ..ctx.. =contains=> {::request-context/org ..org..}
         (async/promise-chan) => ..ch..
         (authz/get-authorizations ..ctx.. ..url.. ..ch..) => ..go..
-        (util/<?? ..ch..) => ..result..))))
+        (util/<?? ..ch..) => ..result..)))
+
+
+  (facts "`get-team-group-project-ids`"
+    (fact "Gets projects by group->projects UUIDs"
+      (let [group-id    1
+            rails-group {:team_ids ..ids..}
+            authz       (authz/new-authz-service ..url..)]
+
+        (authz/get-team-group-project-ids authz ..ctx.. group-id) => ..ids..
+        (provided
+          (authz/get-team-group authz ..ctx.. group-id) => {:team-group rails-group})))))
+

--- a/test/ovation/test/groups.clj
+++ b/test/ovation/test/groups.clj
@@ -5,6 +5,3 @@
             [ovation.authz :as authz]
             [org.httpkit.fake :refer [with-fake-http]]
             [ovation.core :as core]))
-
-
-

--- a/test/ovation/test/groups.clj
+++ b/test/ovation/test/groups.clj
@@ -2,9 +2,9 @@
   (:use midje.sweet)
   (:require [ovation.groups :as groups]
             [ovation.util :as util]
-            [ovation.request-context :as request-context]
-            [clojure.core.async :as async]))
+            [ovation.authz :as authz]
+            [org.httpkit.fake :refer [with-fake-http]]
+            [ovation.core :as core]))
 
 
-(facts "About `get-group-projects`"
-  (future-fact "Gets projects by group->projects UUIDs"))
+

--- a/test/ovation/test/groups.clj
+++ b/test/ovation/test/groups.clj
@@ -1,0 +1,10 @@
+(ns ovation.test.groups
+  (:use midje.sweet)
+  (:require [ovation.groups :as groups]
+            [ovation.util :as util]
+            [ovation.request-context :as request-context]
+            [clojure.core.async :as async]))
+
+
+(facts "About `get-group-projects`"
+  (future-fact "Gets projects by group->projects UUIDs"))

--- a/test/ovation/test/organizations.clj
+++ b/test/ovation/test/organizations.clj
@@ -145,7 +145,7 @@
                                   :type            "OrganizationGroup"
                                   :user_id         user-id
                                   :organization_id org-id
-                                  :team_uuids      team-uuids
+                                  :team_ids      team-uuids
                                   :links           {:self              {:id id, :org org-id}
                                                     :group-memberships {:id id, :org org-id}}}]
               (orgs/get-groups ..ctx.. service-url c)


### PR DESCRIPTION
Adds optional query parameter for `/projects`. When present, returns projects for the given group.