### PR TITLE
Filter projects by organization member [Delivers #148540895]

### DIFF
--- a/src/ovation/authz.clj
+++ b/src/ovation/authz.clj
@@ -5,8 +5,7 @@
             [clojure.core.async :as async :refer [chan go <!]]
             [ovation.util :refer [<??]]
             [ovation.http :as http]
-            [ovation.groups :as groups]
-            [ovation.teams :as teams]))
+            [ovation.groups :as groups]))
 
 
 (defprotocol AuthzApi
@@ -26,14 +25,11 @@
   (put-organization-membership [this ctx id body])
   (delete-organization-membership [this ctx id])
 
-  (get-organization-member-project-ids [this ctx member-id])
-
   (get-organization-groups [this ctx])
   (create-organization-group [this ctx body])
   (get-organization-group [this ctx id])
   (put-organization-group [this ctx id body])
   (delete-organization-group [this ctx id])
-  (get-organization-group-project-ids [this ctx group-id])
 
   (get-organization-groups-memberships [this ctx group-id])
   (create-organization-group-membership [this ctx body])
@@ -45,7 +41,11 @@
   (post-team-group [this ctx body])
   (get-team-group [this ctx group-id])
   (put-team-group [this ctx group-id body])
-  (delete-team-group [this ctx group-id]))
+  (delete-team-group [this ctx group-id])
+
+
+  (get-organization-member-project-ids [this ctx member-id])
+  (get-organization-group-project-ids [this ctx group-id]))
 
 (defn get-authorizations
   [ctx url-base ch]
@@ -231,7 +231,7 @@
 
   (get-organization-member-project-ids [this ctx member-id]
     (let [ch (chan)]
-      (teams/member-teams ctx (:services-url this) member-id ch)
+      (organizations/member-project-ids ctx (:services-url this) member-id ch)
       (<?? ch))))
 
 

--- a/src/ovation/authz.clj
+++ b/src/ovation/authz.clj
@@ -25,6 +25,8 @@
   (put-organization-membership [this ctx id body])
   (delete-organization-membership [this ctx id])
 
+  (get-organization-member-project-ids [this ctx member-id])
+
   (get-organization-groups [this ctx])
   (create-organization-group [this ctx body])
   (get-organization-group [this ctx id])
@@ -224,7 +226,10 @@
   (get-organization-group-project-ids [this ctx group-id]
     (let [ch (chan)]
       (organizations/group-project-ids ctx (:services-url this) group-id ch)
-      (<?? ch))))
+      (<?? ch)))
+
+  (get-organization-member-project-ids [this ctx member-id]
+    (let [ch (chan)])))
 
 
 (defn new-authz-service [services-url]

--- a/src/ovation/authz.clj
+++ b/src/ovation/authz.clj
@@ -5,7 +5,8 @@
             [clojure.core.async :as async :refer [chan go <!]]
             [ovation.util :refer [<??]]
             [ovation.http :as http]
-            [ovation.groups :as groups]))
+            [ovation.groups :as groups]
+            [ovation.teams :as teams]))
 
 
 (defprotocol AuthzApi
@@ -229,7 +230,9 @@
       (<?? ch)))
 
   (get-organization-member-project-ids [this ctx member-id]
-    (let [ch (chan)])))
+    (let [ch (chan)]
+      (teams/member-teams ctx (:services-url this) member-id ch)
+      (<?? ch))))
 
 
 (defn new-authz-service [services-url]

--- a/src/ovation/handler.clj
+++ b/src/ovation/handler.clj
@@ -371,7 +371,8 @@
                   (GET "/" request
                     :name :all-projects
                     :return {:projects [Project]}
-                    :query-params [{organization_group_id :- Id nil}]
+                    :query-params [{organization_group_id :- Id nil}
+                                   {organization_membership_id :- Id nil}]
                     :summary "Gets all top-level projects"
                     (let [ctx      (request-context/make-context request org authz)
                           group-id organization_group_id]

--- a/src/ovation/teams.clj
+++ b/src/ovation/teams.clj
@@ -104,13 +104,6 @@
     :response-key :team
     :make-tf make-read-team-tf))
 
-(defn member-teams
-  [ctx url org-membership-id ch]
-  (http/index-resource ctx url TEAMS ch
-    :query-params {:organization_membership_id org-membership-id}
-    :response-key :teams
-    :make-tf make-read-team-tf))
-
 
 (defn get-team*
   [ctx db team-id]

--- a/src/ovation/teams.clj
+++ b/src/ovation/teams.clj
@@ -15,7 +15,7 @@
             [ovation.core :as core]
             [ovation.auth :as auth]))
 
-
+(def TEAMS "teams")
 
 (defn get-teams
   "Gets all teams for authenticated user as a future assoc: @{:user_uuid id :team_uuids [id1 id2] :organization_ids [id1 id2]}"
@@ -29,7 +29,6 @@
                 (-> resp
                   :body
                   util/from-json))))))
-
 
 (defn make-read-membership-tf
   [team-uuid]
@@ -103,6 +102,13 @@
   [ctx team-id ch]
   (http/show-resource ctx config/TEAMS_SERVER "teams" team-id ch
     :response-key :team
+    :make-tf make-read-team-tf))
+
+(defn member-teams
+  [ctx url org-membership-id ch]
+  (http/index-resource ctx url TEAMS ch
+    :query-params {:organization_membership_id org-membership-id}
+    :response-key :teams
     :make-tf make-read-team-tf))
 
 

--- a/test/ovation/test/organizations.clj
+++ b/test/ovation/test/organizations.clj
@@ -9,7 +9,8 @@
             [ovation.routes :as routes]
             [ovation.test.helpers :refer [sling-throwable]]
             [slingshot.slingshot :refer [try+]]
-            [ovation.organizations :as organizations])
+            [ovation.organizations :as organizations]
+            [ovation.teams :as teams])
   (:import (clojure.lang ExceptionInfo)))
 
 (facts "groups-memberships"
@@ -174,6 +175,7 @@
 
 
               (<?? (organizations/group-project-ids ..ctx.. service-url id ch)) => team-uuids))))
+
 
 
       (facts "`create-group`"

--- a/test/ovation/test/teams.clj
+++ b/test/ovation/test/teams.clj
@@ -37,6 +37,13 @@
       (let [service-url   (util/join-path [config/SERVICES_API_URL "api" "v2"])
             rails-team    {:type k/TEAM-TYPE
                            :uuid (str (util/make-uuid))}
+            expected-team (-> rails-team
+                            (assoc-in [:links :memberships] {:id  nil
+                                                             :org ..org..})
+                            (assoc-in [:links :self] {:id  nil
+                                                      :org ..org..})
+                            (assoc :memberships '())
+                            (assoc :permissions {:delete false :update false}))
             membership-id 1000
             authz-ch      (async/promise-chan)
             _             (async/go (async/>! authz-ch {}))]
@@ -46,7 +53,7 @@
             (fact "Gets project ids from group.team_uuids"
               (let [ch (async/chan)]
                 (teams/member-teams ..ctx.. service-url membership-id ch)
-                (<?? ch) => [rails-team]))))))
+                (<?? ch) => [expected-team]))))))
 
     (facts "get-team* "
       (against-background []


### PR DESCRIPTION
Adds `organization_membership_id` query parameter to `api/v1/projects` so that the projects of an organization member can be listed. 

Proxies Rails `/api/v2/teams`