### PR TITLE
or-1.11.2

### DIFF
--- a/src/ovation/schema.clj
+++ b/src/ovation/schema.clj
@@ -59,22 +59,23 @@
                       (s/optional-key :inverse_rel) s/Str
                       (s/optional-key :name)        s/Str})
 
-(s/defschema LinkInfo {:_id                           s/Str
-                       (s/optional-key :_rev)         s/Str
-                       :type                          (s/eq util/RELATION_TYPE)
+(s/defschema LinkInfo {:_id                              s/Str
+                       (s/optional-key :_rev)            s/Str
+                       :type                             (s/eq util/RELATION_TYPE)
 
-                       :user_id                       s/Uuid
-                       :source_id                     s/Uuid
-                       :target_id                     s/Uuid
-                       :rel                           s/Str
-                       (s/optional-key :organization) s/Int
-                       (s/optional-key :name)         s/Str
-                       (s/optional-key :inverse_rel)  s/Str
+                       :user_id                          s/Uuid
+                       :source_id                        s/Uuid
+                       :target_id                        s/Uuid
+                       :rel                              s/Str
+                       (s/optional-key :organization)    s/Int
+                       (s/optional-key :organization_id) s/Int
+                       (s/optional-key :name)            s/Str
+                       (s/optional-key :inverse_rel)     s/Str
 
-                       (s/optional-key :attributes)   {s/Keyword s/Any}
+                       (s/optional-key :attributes)      {s/Keyword s/Any}
 
-                       :links                         {(s/optional-key :_collaboration_roots) [s/Str]
-                                                       (s/optional-key :self)                 s/Str}})
+                       :links                            {(s/optional-key :_collaboration_roots) [s/Str]
+                                                          (s/optional-key :self)                 s/Str}})
 
 
 


### PR DESCRIPTION
Fixes schema to allow `organization_id` on `LinkInfo`