### PR TITLE
[Delivers #157229069] Activities empty contents for non-owner

### DIFF
--- a/src/ovation/db/sql/relations.sql
+++ b/src/ovation/db/sql/relations.sql
@@ -110,6 +110,7 @@ SELECT
   `source_uuid`.`uuid` AS `source_id`,
   `target_uuid`.`uuid` AS `target_id`,
   `users`.`uuid` AS `user_id`,
+  `or_projects`.`uuid` AS `project`,
   "Relation" as `type`
 FROM `or_relations`
 INNER JOIN `uuids` AS `source_uuid` ON `source_uuid`.`entity_id` = `or_relations`.`source_id`
@@ -117,7 +118,7 @@ INNER JOIN `uuids` AS `source_uuid` ON `source_uuid`.`entity_id` = `or_relations
 INNER JOIN `uuids` AS `target_uuid` ON `target_uuid`.`entity_id` = `or_relations`.`target_id`
   AND `target_uuid`.`entity_type` = `or_relations`.`target_type`
 INNER JOIN `users` ON `users`.`id` = `or_relations`.`user_id`
-LEFT JOIN `or_projects` ON `or_projects`.`id` = `or_relations`.`project_id`
+INNER JOIN `or_projects` ON `or_projects`.`id` = `or_relations`.`project_id`
 WHERE `or_relations`.`uuid` IN (:v*:ids)
 
 -- :name find-all-by-parent-entity-rel :? :*
@@ -131,6 +132,7 @@ SELECT
   `source_uuid`.`uuid` AS `source_id`,
   `target_uuid`.`uuid` AS `target_id`,
   `users`.`uuid` AS `user_id`,
+  `or_projects`.`uuid` AS `project`,
   "Relation" as `type`
 FROM `or_relations`
 INNER JOIN `uuids` AS `source_uuid` ON `source_uuid`.`entity_id` = `or_relations`.`source_id`
@@ -138,7 +140,7 @@ INNER JOIN `uuids` AS `source_uuid` ON `source_uuid`.`entity_id` = `or_relations
 INNER JOIN `uuids` AS `target_uuid` ON `target_uuid`.`entity_id` = `or_relations`.`target_id`
   AND `target_uuid`.`entity_type` = `or_relations`.`target_type`
 INNER JOIN `users` ON `users`.`id` = `or_relations`.`user_id`
-LEFT JOIN `or_projects` ON `or_projects`.`id` = `or_relations`.`project_id`
+INNER JOIN `or_projects` ON `or_projects`.`id` = `or_relations`.`project_id`
 WHERE `or_relations`.`source_id` = :entity_id
   AND `or_relations`.`source_type` = :entity_type
   AND `or_relations`.`rel` = :rel

--- a/src/ovation/transform/read.clj
+++ b/src/ovation/transform/read.clj
@@ -240,17 +240,12 @@
                         (dissoc :start)
                         (dissoc :end))))
 
-(defn add-relation-collaboration-roots
-  [doc ctx]
-  (-> doc
-    (assoc-in [:links :_collaboration_roots] [(:source_id doc)])))
-
 (defn-traced db-to-value
   [ctx]
   (fn [doc]
     (condp = (:type doc)
       c/RELATION-TYPE (-> doc
-                        (add-relation-collaboration-roots ctx)
+                        (add-collaboration-roots ctx)
                         (add-self-link ctx)
                         (remove-id))
       c/ANNOTATION-TYPE (-> doc

--- a/test/ovation/test/transform/read.clj
+++ b/test/ovation/test/transform/read.clj
@@ -177,11 +177,12 @@
     (facts "for relations"
       (let [record {:_id ..id..
                     :type c/RELATION-TYPE
-                    :source_id ..source..}
+                    :source_id ..source..
+                    :project ..project..}
             transformed-record {:_id ..id..
                                 :type c/RELATION-TYPE
                                 :source_id ..source..
-                                :links {:_collaboration_roots [..source..]
+                                :links {:_collaboration_roots [..project..]
                                         :self {:id ..id..
                                                :org ..org..}}}]
         (fact "it adds collaboration roots and self link"


### PR DESCRIPTION
## Changes

- use `project` instead of `source_id` in relation collaboration roots